### PR TITLE
fix: update to new lvt testing API

### DIFF
--- a/avatar-upload/avatar-upload_test.go
+++ b/avatar-upload/avatar-upload_test.go
@@ -47,8 +47,10 @@ func TestAvatarUploadE2E(t *testing.T) {
 	}()
 
 	// Start Docker Chrome container
-	chromeCmd := e2etest.StartDockerChrome(t, debugPort)
-	defer e2etest.StopDockerChrome(t, chromeCmd, debugPort)
+	if err := e2etest.StartDockerChrome(t, debugPort); err != nil {
+		t.Fatalf("Failed to start Chrome: %v", err)
+	}
+	defer e2etest.StopDockerChrome(t, debugPort)
 
 	// Connect to Docker Chrome via remote debugging
 	chromeURL := fmt.Sprintf("http://localhost:%d", debugPort)

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -52,8 +52,10 @@ func TestCounterE2E(t *testing.T) {
 	}()
 
 	// Start Docker Chrome container
-	chromeCmd := e2etest.StartDockerChrome(t, debugPort)
-	defer e2etest.StopDockerChrome(t, chromeCmd, debugPort)
+	if err := e2etest.StartDockerChrome(t, debugPort); err != nil {
+		t.Fatalf("Failed to start Chrome: %v", err)
+	}
+	defer e2etest.StopDockerChrome(t, debugPort)
 
 	// Connect to Docker Chrome via remote debugging
 	chromeURL := fmt.Sprintf("http://localhost:%d", debugPort)

--- a/todos/todos_test.go
+++ b/todos/todos_test.go
@@ -104,8 +104,10 @@ func TestTodosE2E(t *testing.T) {
 	t.Logf("✅ Test server ready at %s", serverURL)
 
 	// Start Docker Chrome container
-	chromeCmd := e2etest.StartDockerChrome(t, debugPort)
-	defer e2etest.StopDockerChrome(t, chromeCmd, debugPort)
+	if err := e2etest.StartDockerChrome(t, debugPort); err != nil {
+		t.Fatalf("Failed to start Chrome: %v", err)
+	}
+	defer e2etest.StopDockerChrome(t, debugPort)
 
 	// Connect to Docker Chrome via remote debugging
 	chromeURL := fmt.Sprintf("http://localhost:%d", debugPort)


### PR DESCRIPTION
## Summary

Update all examples to use the new lvt testing API:
- `StartDockerChrome` now returns `error` instead of `*exec.Cmd`
- `StopDockerChrome` now takes `(t, debugPort)` instead of `(t, cmd, debugPort)`

This aligns with the latest lvt/testing package changes and fixes the cross-repo test failures.

## Files Changed

- `avatar-upload/avatar-upload_test.go`
- `counter/counter_test.go`
- `todos/todos_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)