### PR TITLE
feat(todos): refactor to demonstrate controller/state separation with lvt:state

### DIFF
--- a/todos/main.go
+++ b/todos/main.go
@@ -46,10 +46,40 @@ type PaginationInput struct {
 	Page int `json:"page" validate:"required,min=1"`
 }
 
-// TodoState demonstrates the Controller pattern with automatic method dispatch.
+// TodoPrefs holds user preferences that persist across sessions.
+// These are the minimal settings needed to restore the user's view state.
+type TodoPrefs struct {
+	SearchQuery string `json:"search_query"`
+	SortBy      string `json:"sort_by"`
+	CurrentPage int    `json:"current_page"`
+	PageSize    int    `json:"page_size"`
+}
+
+// TodoView holds computed/derived fields for template rendering.
+// These are recalculated by loadTodos() and NOT persisted to Redis.
+type TodoView struct {
+	FilteredTodos  []TodoItem `json:"filtered_todos"`
+	PaginatedTodos []TodoItem `json:"paginated_todos"`
+	TotalCount     int        `json:"total_count"`
+	CompletedCount int        `json:"completed_count"`
+	RemainingCount int        `json:"remaining_count"`
+	TotalPages     int        `json:"total_pages"`
+	ShowPagination bool       `json:"show_pagination"`
+	PrevDisabled   bool       `json:"prev_disabled"`
+	NextDisabled   bool       `json:"next_disabled"`
+	LastUpdated    string     `json:"last_updated"`
+}
+
+// TodoController demonstrates the Controller pattern with automatic method dispatch
+// and proper state separation using the lvt:state tag.
 //
-// Instead of implementing the Store interface with a Change() switch statement,
-// each action maps directly to a method:
+// Fields tagged with `lvt:"state"` are persisted to Redis/session storage.
+// Fields without the tag (dependencies like DB) come from the template clone.
+//
+// Note: The DB field must be exported for reflection-based cloning to work.
+// Use `json:"-"` to exclude it from JSON serialization.
+//
+// Actions are automatically dispatched to methods:
 //
 //   - "add"             → Add(ctx)
 //   - "toggle"          → Toggle(ctx)
@@ -62,27 +92,23 @@ type PaginationInput struct {
 //   - "clear_completed" → ClearCompleted(ctx)
 //
 // Actions support both snake_case (next_page) and camelCase (nextPage).
-type TodoState struct {
-	Title          string      `json:"title"`
-	Queries        *db.Queries `json:"-"` // Database queries (exported but not in JSON)
-	SearchQuery    string      `json:"search_query"`
-	SortBy         string      `json:"sort_by"`
-	FilteredTodos  []TodoItem  `json:"filtered_todos"`
-	CurrentPage    int         `json:"current_page"`
-	PageSize       int         `json:"page_size"`
-	TotalPages     int         `json:"total_pages"`
-	PaginatedTodos []TodoItem  `json:"paginated_todos"`
-	TotalCount     int         `json:"total_count"`
-	CompletedCount int         `json:"completed_count"`
-	RemainingCount int         `json:"remaining_count"`
-	LastUpdated    string      `json:"last_updated"`
-	ShowPagination bool        `json:"show_pagination"`
-	PrevDisabled   bool        `json:"prev_disabled"`
-	NextDisabled   bool        `json:"next_disabled"`
+type TodoController struct {
+	// Configuration (static, copied from template)
+	Title string `json:"title"`
+
+	// State fields - PERSISTED to Redis via lvt:"state" tag
+	Prefs *TodoPrefs `json:"prefs" lvt:"state"`
+
+	// Computed fields - NOT persisted, recalculated on Init()
+	View *TodoView `json:"view"`
+
+	// Dependencies - NOT persisted, come from template clone
+	// Must be exported for reflection-based cloning; json:"-" excludes from serialization
+	DB *db.Queries `json:"-"`
 }
 
 // Add handles the "add" action - creates a new todo item
-func (s *TodoState) Add(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) Add(ctx *livetemplate.ActionContext) error {
 	var input AddInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
@@ -94,7 +120,7 @@ func (s *TodoState) Add(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
 	// Insert into database
-	_, err := s.Queries.CreateTodo(dbCtx, db.CreateTodoParams{
+	_, err := c.DB.CreateTodo(dbCtx, db.CreateTodoParams{
 		ID:        id,
 		Text:      input.Text,
 		Completed: false,
@@ -104,12 +130,12 @@ func (s *TodoState) Add(ctx *livetemplate.ActionContext) error {
 		return fmt.Errorf("failed to create todo: %w", err)
 	}
 
-	s.LastUpdated = formatTime()
-	return s.loadTodos(dbCtx)
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(dbCtx)
 }
 
 // Toggle handles the "toggle" action - toggles todo completion status
-func (s *TodoState) Toggle(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) Toggle(ctx *livetemplate.ActionContext) error {
 	var input ToggleInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
@@ -118,13 +144,13 @@ func (s *TodoState) Toggle(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
 	// Get current todo to toggle its completed status
-	todo, err := s.Queries.GetTodoByID(dbCtx, input.ID)
+	todo, err := c.DB.GetTodoByID(dbCtx, input.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get todo: %w", err)
 	}
 
 	// Update in database
-	err = s.Queries.UpdateTodoCompleted(dbCtx, db.UpdateTodoCompletedParams{
+	err = c.DB.UpdateTodoCompleted(dbCtx, db.UpdateTodoCompletedParams{
 		Completed: !todo.Completed,
 		ID:        input.ID,
 	})
@@ -132,12 +158,12 @@ func (s *TodoState) Toggle(ctx *livetemplate.ActionContext) error {
 		return fmt.Errorf("failed to update todo: %w", err)
 	}
 
-	s.LastUpdated = formatTime()
-	return s.loadTodos(dbCtx)
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(dbCtx)
 }
 
 // Delete handles the "delete" action - removes a todo item
-func (s *TodoState) Delete(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) Delete(ctx *livetemplate.ActionContext) error {
 	var input DeleteInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
@@ -146,194 +172,199 @@ func (s *TodoState) Delete(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
 	// Delete from database
-	err := s.Queries.DeleteTodo(dbCtx, input.ID)
+	err := c.DB.DeleteTodo(dbCtx, input.ID)
 	if err != nil {
 		return fmt.Errorf("failed to delete todo: %w", err)
 	}
 
-	s.LastUpdated = formatTime()
-	return s.loadTodos(dbCtx)
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(dbCtx)
 }
 
 // Search handles the "search" action - filters todos by search query
-func (s *TodoState) Search(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) Search(ctx *livetemplate.ActionContext) error {
 	var input SearchInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
 	}
-	s.SearchQuery = input.Query
-	s.LastUpdated = formatTime()
-	return s.loadTodos(context.Background())
+	c.Prefs.SearchQuery = input.Query
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(context.Background())
 }
 
 // Sort handles the "sort" action - changes todo sort order
-func (s *TodoState) Sort(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) Sort(ctx *livetemplate.ActionContext) error {
 	var input SortInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
 	}
-	s.SortBy = input.SortBy
-	s.LastUpdated = formatTime()
-	return s.loadTodos(context.Background())
+	c.Prefs.SortBy = input.SortBy
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(context.Background())
 }
 
 // NextPage handles the "next_page" action - navigates to next page
-func (s *TodoState) NextPage(ctx *livetemplate.ActionContext) error {
-	if s.CurrentPage < s.TotalPages {
-		s.CurrentPage++
+func (c *TodoController) NextPage(ctx *livetemplate.ActionContext) error {
+	if c.Prefs.CurrentPage < c.View.TotalPages {
+		c.Prefs.CurrentPage++
 	}
-	s.LastUpdated = formatTime()
-	return s.loadTodos(context.Background())
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(context.Background())
 }
 
 // PrevPage handles the "prev_page" action - navigates to previous page
-func (s *TodoState) PrevPage(ctx *livetemplate.ActionContext) error {
-	if s.CurrentPage > 1 {
-		s.CurrentPage--
+func (c *TodoController) PrevPage(ctx *livetemplate.ActionContext) error {
+	if c.Prefs.CurrentPage > 1 {
+		c.Prefs.CurrentPage--
 	}
-	s.LastUpdated = formatTime()
-	return s.loadTodos(context.Background())
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(context.Background())
 }
 
 // GotoPage handles the "goto_page" action - navigates to specific page
-func (s *TodoState) GotoPage(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) GotoPage(ctx *livetemplate.ActionContext) error {
 	var input PaginationInput
 	if err := ctx.BindAndValidate(&input, validate); err != nil {
 		return err
 	}
-	if input.Page >= 1 && input.Page <= s.TotalPages {
-		s.CurrentPage = input.Page
+	if input.Page >= 1 && input.Page <= c.View.TotalPages {
+		c.Prefs.CurrentPage = input.Page
 	}
-	s.LastUpdated = formatTime()
-	return s.loadTodos(context.Background())
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(context.Background())
 }
 
 // ClearCompleted handles the "clear_completed" action - removes all completed todos
-func (s *TodoState) ClearCompleted(ctx *livetemplate.ActionContext) error {
+func (c *TodoController) ClearCompleted(ctx *livetemplate.ActionContext) error {
 	dbCtx := context.Background()
 
 	// Delete all completed todos from database
-	err := s.Queries.DeleteCompletedTodos(dbCtx)
+	err := c.DB.DeleteCompletedTodos(dbCtx)
 	if err != nil {
 		return fmt.Errorf("failed to delete completed todos: %w", err)
 	}
 
-	s.LastUpdated = formatTime()
-	return s.loadTodos(dbCtx)
+	c.View.LastUpdated = formatTime()
+	return c.loadTodos(dbCtx)
 }
 
 // Init implements livetemplate.StoreInitializer
 // This is called when the store is cloned for a new session (e.g., page refresh)
-func (s *TodoState) Init() error {
-	return s.loadTodos(context.Background())
+// For session restore: Template clone provides db, lvt:state injects Prefs, then Init() recalculates View
+func (c *TodoController) Init() error {
+	// Ensure Prefs exists (may be nil for new sessions)
+	if c.Prefs == nil {
+		c.Prefs = &TodoPrefs{
+			CurrentPage: 1,
+			PageSize:    3,
+		}
+	}
+
+	// Ensure View exists
+	if c.View == nil {
+		c.View = &TodoView{}
+	}
+
+	// Load and compute view from database
+	return c.loadTodos(context.Background())
 }
 
-// loadTodos loads todos from database and updates computed fields
-func (s *TodoState) loadTodos(ctx context.Context) error {
+// loadTodos loads todos from database and updates computed fields in View
+func (c *TodoController) loadTodos(ctx context.Context) error {
 	// Get all todos from database
-	todos, err := s.Queries.GetAllTodos(ctx)
+	todos, err := c.DB.GetAllTodos(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load todos: %w", err)
 	}
 
 	// Apply search filter
-	if s.SearchQuery == "" {
-		s.FilteredTodos = todos
+	if c.Prefs.SearchQuery == "" {
+		c.View.FilteredTodos = todos
 	} else {
-		s.FilteredTodos = []TodoItem{}
-		query := strings.ToLower(s.SearchQuery)
+		c.View.FilteredTodos = []TodoItem{}
+		query := strings.ToLower(c.Prefs.SearchQuery)
 		for _, todo := range todos {
 			if strings.Contains(strings.ToLower(todo.Text), query) {
-				s.FilteredTodos = append(s.FilteredTodos, todo)
+				c.View.FilteredTodos = append(c.View.FilteredTodos, todo)
 			}
 		}
 	}
 
 	// Update statistics
-	s.TotalCount = len(todos)
-	s.CompletedCount = 0
+	c.View.TotalCount = len(todos)
+	c.View.CompletedCount = 0
 	for _, todo := range todos {
 		if todo.Completed {
-			s.CompletedCount++
+			c.View.CompletedCount++
 		}
 	}
-	s.RemainingCount = s.TotalCount - s.CompletedCount
+	c.View.RemainingCount = c.View.TotalCount - c.View.CompletedCount
 
 	// Apply sorting and pagination
-	s.applySorting()
-	s.applyPagination()
+	c.applySorting()
+	c.applyPagination()
 
 	return nil
 }
 
-func (s *TodoState) updateStats() {
-	// Stats are now calculated in loadTodos
-	// This is kept for backward compatibility but does nothing
-}
-
-func (s *TodoState) updateFilteredTodos() {
-	// Filtering is now done in loadTodos
-	// This is kept for backward compatibility but does nothing
-}
-
-func (s *TodoState) applySorting() {
-	switch s.SortBy {
+func (c *TodoController) applySorting() {
+	switch c.Prefs.SortBy {
 	case "alphabetical":
-		sort.Slice(s.FilteredTodos, func(i, j int) bool {
-			return strings.ToLower(s.FilteredTodos[i].Text) < strings.ToLower(s.FilteredTodos[j].Text)
+		sort.Slice(c.View.FilteredTodos, func(i, j int) bool {
+			return strings.ToLower(c.View.FilteredTodos[i].Text) < strings.ToLower(c.View.FilteredTodos[j].Text)
 		})
 	case "reverse_alphabetical":
-		sort.Slice(s.FilteredTodos, func(i, j int) bool {
-			return strings.ToLower(s.FilteredTodos[i].Text) > strings.ToLower(s.FilteredTodos[j].Text)
+		sort.Slice(c.View.FilteredTodos, func(i, j int) bool {
+			return strings.ToLower(c.View.FilteredTodos[i].Text) > strings.ToLower(c.View.FilteredTodos[j].Text)
 		})
 	case "oldest_first":
-		sort.Slice(s.FilteredTodos, func(i, j int) bool {
-			return s.FilteredTodos[i].CreatedAt.Before(s.FilteredTodos[j].CreatedAt)
+		sort.Slice(c.View.FilteredTodos, func(i, j int) bool {
+			return c.View.FilteredTodos[i].CreatedAt.Before(c.View.FilteredTodos[j].CreatedAt)
 		})
 	default:
 		// Default: newest first (reverse chronological)
-		sort.Slice(s.FilteredTodos, func(i, j int) bool {
-			return s.FilteredTodos[i].CreatedAt.After(s.FilteredTodos[j].CreatedAt)
+		sort.Slice(c.View.FilteredTodos, func(i, j int) bool {
+			return c.View.FilteredTodos[i].CreatedAt.After(c.View.FilteredTodos[j].CreatedAt)
 		})
 	}
 }
 
-func (s *TodoState) applyPagination() {
+func (c *TodoController) applyPagination() {
 	// Calculate total pages
-	if len(s.FilteredTodos) == 0 {
-		s.TotalPages = 1
-		s.CurrentPage = 1
-		s.PaginatedTodos = []TodoItem{}
-		s.ShowPagination = false
-		s.PrevDisabled = true
-		s.NextDisabled = true
+	if len(c.View.FilteredTodos) == 0 {
+		c.View.TotalPages = 1
+		c.Prefs.CurrentPage = 1
+		c.View.PaginatedTodos = []TodoItem{}
+		c.View.ShowPagination = false
+		c.View.PrevDisabled = true
+		c.View.NextDisabled = true
 		return
 	}
 
-	s.TotalPages = int(math.Ceil(float64(len(s.FilteredTodos)) / float64(s.PageSize)))
+	c.View.TotalPages = int(math.Ceil(float64(len(c.View.FilteredTodos)) / float64(c.Prefs.PageSize)))
 
 	// Validate and adjust current page if needed
-	if s.CurrentPage < 1 {
-		s.CurrentPage = 1
+	if c.Prefs.CurrentPage < 1 {
+		c.Prefs.CurrentPage = 1
 	}
-	if s.CurrentPage > s.TotalPages {
-		s.CurrentPage = s.TotalPages
+	if c.Prefs.CurrentPage > c.View.TotalPages {
+		c.Prefs.CurrentPage = c.View.TotalPages
 	}
 
 	// Calculate start and end indices for current page
-	start := (s.CurrentPage - 1) * s.PageSize
-	end := start + s.PageSize
-	if end > len(s.FilteredTodos) {
-		end = len(s.FilteredTodos)
+	start := (c.Prefs.CurrentPage - 1) * c.Prefs.PageSize
+	end := start + c.Prefs.PageSize
+	if end > len(c.View.FilteredTodos) {
+		end = len(c.View.FilteredTodos)
 	}
 
 	// Slice to get current page items
-	s.PaginatedTodos = s.FilteredTodos[start:end]
+	c.View.PaginatedTodos = c.View.FilteredTodos[start:end]
 
-	hasPaginated := len(s.PaginatedTodos) > 0
-	s.ShowPagination = hasPaginated && s.TotalPages > 1
-	s.PrevDisabled = !hasPaginated || s.CurrentPage <= 1
-	s.NextDisabled = !hasPaginated || s.CurrentPage >= s.TotalPages
+	hasPaginated := len(c.View.PaginatedTodos) > 0
+	c.View.ShowPagination = hasPaginated && c.View.TotalPages > 1
+	c.View.PrevDisabled = !hasPaginated || c.Prefs.CurrentPage <= 1
+	c.View.NextDisabled = !hasPaginated || c.Prefs.CurrentPage >= c.View.TotalPages
 }
 
 func formatTime() string {
@@ -362,17 +393,21 @@ func main() {
 	}
 	defer CloseDB()
 
-	// Create initial state
-	state := &TodoState{
-		Title:       "Todo App",
-		Queries:     queries,
-		CurrentPage: 1,
-		PageSize:    3,
-		LastUpdated: formatTime(),
+	// Create initial controller with dependencies and state
+	controller := &TodoController{
+		Title: "Todo App",
+		DB:    queries, // Dependency - not persisted (json:"-")
+		Prefs: &TodoPrefs{
+			CurrentPage: 1,
+			PageSize:    3,
+		},
+		View: &TodoView{
+			LastUpdated: formatTime(),
+		},
 	}
 
 	// Load initial todos from database
-	if err := state.loadTodos(context.Background()); err != nil {
+	if err := controller.loadTodos(context.Background()); err != nil {
 		log.Fatalf("Failed to load initial todos: %v", err)
 	}
 
@@ -381,7 +416,7 @@ func main() {
 	tmpl := livetemplate.Must(livetemplate.New("todos", envConfig.ToOptions()...))
 
 	// Mount handler - auto-handles initial page, WebSocket, and HTTP actions
-	http.Handle("/", tmpl.Handle(state))
+	http.Handle("/", tmpl.Handle(controller))
 
 	// Serve client library (development only - use CDN in production)
 	http.HandleFunc("/livetemplate-client.js", e2etest.ServeClientLibrary)

--- a/todos/todos.tmpl
+++ b/todos/todos.tmpl
@@ -39,9 +39,9 @@
         <!-- Statistics -->
         <p>
           <small>
-            Total: <strong>{{ .TotalCount }}</strong> • Completed:
-            <strong>{{ .CompletedCount }}</strong> • Remaining:
-            <strong>{{ .RemainingCount }}</strong>
+            Total: <strong>{{ .View.TotalCount }}</strong> • Completed:
+            <strong>{{ .View.CompletedCount }}</strong> • Remaining:
+            <strong>{{ .View.RemainingCount }}</strong>
           </small>
         </p>
 
@@ -51,7 +51,7 @@
             type="search"
             name="query"
             placeholder="Search todos..."
-            value="{{ .SearchQuery }}"
+            value="{{ .Prefs.SearchQuery }}"
           />
         </form>
 
@@ -59,24 +59,24 @@
         <div>
           <label for="sort_by">Sort by:</label>
           <select name="sort_by" id="sort_by" lvt-change="sort">
-            <option value="" {{ if eq .SortBy "" }}selected{{ end }}>
+            <option value="" {{ if eq .Prefs.SortBy "" }}selected{{ end }}>
               Newest First
             </option>
             <option
               value="alphabetical"
-              {{ if eq .SortBy "alphabetical" }}selected{{ end }}
+              {{ if eq .Prefs.SortBy "alphabetical" }}selected{{ end }}
             >
               Alphabetical (A-Z)
             </option>
             <option
               value="reverse_alphabetical"
-              {{ if eq .SortBy "reverse_alphabetical" }}selected{{ end }}
+              {{ if eq .Prefs.SortBy "reverse_alphabetical" }}selected{{ end }}
             >
               Alphabetical (Z-A)
             </option>
             <option
               value="oldest_first"
-              {{ if eq .SortBy "oldest_first" }}selected{{ end }}
+              {{ if eq .Prefs.SortBy "oldest_first" }}selected{{ end }}
             >
               Oldest First
             </option>
@@ -88,7 +88,7 @@
           <header><strong>Tasks</strong></header>
           <table>
             <tbody>
-              {{ range .PaginatedTodos }}
+              {{ range .View.PaginatedTodos }}
                 <tr data-key="{{ .ID }}">
                   <td>
                     <input
@@ -118,9 +118,9 @@
               {{ end }}
             </tbody>
           </table>
-          <p data-empty-state{{ if gt (len .PaginatedTodos) 0 }}hidden{{ end }}>
-            {{ if ne .SearchQuery "" }}
-              <small>No todos found matching "{{ .SearchQuery }}"</small>
+          <p data-empty-state{{ if gt (len .View.PaginatedTodos) 0 }}hidden{{ end }}>
+            {{ if ne .Prefs.SearchQuery "" }}
+              <small>No todos found matching "{{ .Prefs.SearchQuery }}"</small>
             {{ else }}
               <small>No todos yet. Add one above!</small>
             {{ end }}
@@ -130,17 +130,17 @@
           <nav
             data-pagination
             aria-label="Pagination"
-            data-visible="{{- if .ShowPagination -}}
+            data-visible="{{- if .View.ShowPagination -}}
               true
             {{- else -}}
               false
             {{- end -}}"
-            style="display: {{ if .ShowPagination }}
+            style="display: {{ if .View.ShowPagination }}
               block
             {{ else }}
               none
             {{ end }};"
-            {{ if not .ShowPagination }}hidden{{ end }}
+            {{ if not .View.ShowPagination }}hidden{{ end }}
           >
             <ul
               style="display: flex; justify-content: center; align-items: center; gap: 1rem; list-style: none; padding: 0;"
@@ -148,27 +148,27 @@
               <li>
                 <button
                   lvt-click="prev_page"
-                  data-disabled="{{- if .PrevDisabled -}}
+                  data-disabled="{{- if .View.PrevDisabled -}}
                     true
                   {{- else -}}
                     false
                   {{- end -}}"
-                  aria-disabled="{{- if .PrevDisabled -}}
+                  aria-disabled="{{- if .View.PrevDisabled -}}
                     true
                   {{- else -}}
                     false
                   {{- end -}}"
-                  {{ if .PrevDisabled }}disabled{{ end }}
-                  tabindex="{{ if .PrevDisabled }}
+                  {{ if .View.PrevDisabled }}disabled{{ end }}
+                  tabindex="{{ if .View.PrevDisabled }}
                     -1
                   {{ else }}
                     0
                   {{ end }}"
-                  style="pointer-events: {{ if .PrevDisabled }}
+                  style="pointer-events: {{ if .View.PrevDisabled }}
                     none
                   {{ else }}
                     auto
-                  {{ end }}; opacity: {{ if .PrevDisabled }}
+                  {{ end }}; opacity: {{ if .View.PrevDisabled }}
                     0.6
                   {{ else }}
                     1
@@ -179,32 +179,32 @@
                 </button>
               </li>
               <li>
-                <small>Page {{ .CurrentPage }} of {{ .TotalPages }}</small>
+                <small>Page {{ .Prefs.CurrentPage }} of {{ .View.TotalPages }}</small>
               </li>
               <li>
                 <button
                   lvt-click="next_page"
-                  data-disabled="{{- if .NextDisabled -}}
+                  data-disabled="{{- if .View.NextDisabled -}}
                     true
                   {{- else -}}
                     false
                   {{- end -}}"
-                  aria-disabled="{{- if .NextDisabled -}}
+                  aria-disabled="{{- if .View.NextDisabled -}}
                     true
                   {{- else -}}
                     false
                   {{- end -}}"
-                  {{ if .NextDisabled }}disabled{{ end }}
-                  tabindex="{{ if .NextDisabled }}
+                  {{ if .View.NextDisabled }}disabled{{ end }}
+                  tabindex="{{ if .View.NextDisabled }}
                     -1
                   {{ else }}
                     0
                   {{ end }}"
-                  style="pointer-events: {{ if .NextDisabled }}
+                  style="pointer-events: {{ if .View.NextDisabled }}
                     none
                   {{ else }}
                     auto
-                  {{ end }}; opacity: {{ if .NextDisabled }}
+                  {{ end }}; opacity: {{ if .View.NextDisabled }}
                     0.6
                   {{ else }}
                     1
@@ -217,15 +217,15 @@
             </ul>
           </nav>
 
-          {{ if gt .CompletedCount 0 }}
+          {{ if gt .View.CompletedCount 0 }}
             <button lvt-click="clear_completed" class="secondary">
-              Clear Completed ({{ .CompletedCount }})
+              Clear Completed ({{ .View.CompletedCount }})
             </button>
           {{ end }}
         </section>
 
         <footer>
-          <small>Last updated: {{ .LastUpdated }}</small>
+          <small>Last updated: {{ .View.LastUpdated }}</small>
         </footer>
       </article>
     </main>


### PR DESCRIPTION
## Summary

- Refactor monolithic `TodoState` (16 fields) into three focused structs demonstrating the controller/state separation pattern
- Add `lvt:"state"` tag usage to show selective Redis persistence
- Update templates to use nested access patterns

## Changes

### New Struct Organization

| Struct | Purpose | Fields | Persisted? |
|--------|---------|--------|------------|
| `TodoPrefs` | User preferences | SearchQuery, SortBy, CurrentPage, PageSize | Yes (`lvt:"state"`) |
| `TodoView` | Computed display data | FilteredTodos, PaginatedTodos, counts, pagination flags | No |
| `TodoController` | Main controller | Title, Prefs, View, DB | Prefs only |

### Template Updates

All field access now uses nested paths:
- `{{ .TotalCount }}` → `{{ .View.TotalCount }}`
- `{{ .SearchQuery }}` → `{{ .Prefs.SearchQuery }}`
- `{{ range .PaginatedTodos }}` → `{{ range .View.PaginatedTodos }}`

### Benefits Demonstrated

1. **Clear separation**: Dependencies (DB) vs persisted state (Prefs) vs computed (View)
2. **Minimal serialization**: Only 4 fields persist to Redis instead of 16
3. **Self-documenting**: `lvt:"state"` tag shows what survives session restores
4. **Fresh data**: View is always recalculated from database on Init()

## Test plan

- [x] All E2E tests pass
- [x] WebSocket tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)