### PR TITLE
fix: update examples to Controller+State API

### DIFF
--- a/production/single-host/main.go
+++ b/production/single-host/main.go
@@ -15,32 +15,35 @@ import (
 	e2etest "github.com/livetemplate/lvt/testing"
 )
 
-// AppState represents the application state
+// AppState represents the application state (cloned per session)
 type AppState struct {
 	Title       string `json:"title"`
 	Counter     int    `json:"counter"`
 	LastUpdated string `json:"last_updated"`
 }
 
+// AppController handles application actions (singleton, holds dependencies)
+type AppController struct{}
+
 // Increment handles the "increment" action
-func (s *AppState) Increment(_ *livetemplate.ActionContext) error {
-	s.Counter++
-	s.LastUpdated = formatTime()
-	return nil
+func (c *AppController) Increment(state AppState, ctx *livetemplate.Context) (AppState, error) {
+	state.Counter++
+	state.LastUpdated = formatTime()
+	return state, nil
 }
 
 // Decrement handles the "decrement" action
-func (s *AppState) Decrement(_ *livetemplate.ActionContext) error {
-	s.Counter--
-	s.LastUpdated = formatTime()
-	return nil
+func (c *AppController) Decrement(state AppState, ctx *livetemplate.Context) (AppState, error) {
+	state.Counter--
+	state.LastUpdated = formatTime()
+	return state, nil
 }
 
 // Reset handles the "reset" action
-func (s *AppState) Reset(_ *livetemplate.ActionContext) error {
-	s.Counter = 0
-	s.LastUpdated = formatTime()
-	return nil
+func (c *AppController) Reset(state AppState, ctx *livetemplate.Context) (AppState, error) {
+	state.Counter = 0
+	state.LastUpdated = formatTime()
+	return state, nil
 }
 
 func formatTime() string {
@@ -126,8 +129,9 @@ func main() {
 		"shutdown_timeout", envConfig.ShutdownTimeout,
 	)
 
-	// Create initial state
-	state := &AppState{
+	// Create controller and initial state
+	controller := &AppController{}
+	initialState := &AppState{
 		Title:       "Production Demo",
 		Counter:     0,
 		LastUpdated: formatTime(),
@@ -135,7 +139,7 @@ func main() {
 
 	// Create template
 	tmpl := livetemplate.Must(livetemplate.New("app", envConfig.ToOptions()...))
-	liveHandler := tmpl.Handle(state)
+	liveHandler := tmpl.Handle(controller, livetemplate.AsState(initialState))
 
 	// Setup HTTP routes with trace middleware
 	mux := http.NewServeMux()

--- a/testing/01_basic/main.go
+++ b/testing/01_basic/main.go
@@ -9,11 +9,15 @@ import (
 	lvttest "github.com/livetemplate/lvt/testing"
 )
 
+// PageState represents the page data (cloned per session)
 type PageState struct {
 	Title   string
 	Message string
 	Count   int
 }
+
+// PageController handles page actions (singleton, holds dependencies)
+type PageController struct{}
 
 // No action methods needed for this static page
 
@@ -21,15 +25,16 @@ func main() {
 	// Create template (will auto-discover welcome.tmpl)
 	tmpl := livetemplate.Must(livetemplate.New("welcome"))
 
-	// Create state
-	state := &PageState{
+	// Create controller and initial state
+	controller := &PageController{}
+	initialState := &PageState{
 		Title:   "Welcome",
 		Message: "Hello from LiveTemplate!",
 		Count:   42,
 	}
 
-	// Mount handler
-	http.Handle("/", tmpl.Handle(state))
+	// Mount handler with Controller+State pattern
+	http.Handle("/", tmpl.Handle(controller, livetemplate.AsState(initialState)))
 
 	// Serve client library
 	http.HandleFunc("/livetemplate-client.js", lvttest.ServeClientLibrary)


### PR DESCRIPTION
## Summary
- Update testing/01_basic and production/single-host examples to new Controller+State pattern
- Required for livetemplate core PR #70 CI to pass

## Changes
- Change from `tmpl.Handle(state)` to `tmpl.Handle(controller, livetemplate.AsState(state))`
- Update action method signatures to new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)