### PR TITLE
chore: upgrade livetemplate to v0.7.4

### DIFF
--- a/avatar-upload/go.mod
+++ b/avatar-upload/go.mod
@@ -5,7 +5,7 @@ go 1.25.3
 require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d
 )
 

--- a/avatar-upload/go.sum
+++ b/avatar-upload/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d h1:KKaaDPTlSCL/BEz5B+xowvXgOpl0kLpAdWZLIXL/2a0=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d/go.mod h1:iwP3NZgs3EGXd6mTUAK3j4UENr7qhuUmAME44LoTExE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/chat/go.mod
+++ b/chat/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/chromedp/chromedp v0.14.2
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251213063335-769e058d10cd
 )
 

--- a/chat/go.sum
+++ b/chat/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251213063335-769e058d10cd h1:3Ram0HdjMF1gVLvXNJMFw78c3pr9Qfp29W+yFhLVI9A=
 github.com/livetemplate/lvt v0.0.0-20251213063335-769e058d10cd/go.mod h1:iqFfvhrJJ51XkGdEFsy5Ze0+nghSL1n6RFq+5EdUEFY=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/counter/go.mod
+++ b/counter/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d
 )
 

--- a/counter/go.sum
+++ b/counter/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d h1:KKaaDPTlSCL/BEz5B+xowvXgOpl0kLpAdWZLIXL/2a0=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d/go.mod h1:iwP3NZgs3EGXd6mTUAK3j4UENr7qhuUmAME44LoTExE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/graceful-shutdown/go.mod
+++ b/graceful-shutdown/go.mod
@@ -3,7 +3,7 @@ module graceful-shutdown
 go 1.25
 
 require (
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0
 )
 

--- a/graceful-shutdown/go.sum
+++ b/graceful-shutdown/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0 h1:WQcir+LsmAlaihnnRdLUiGefy2J+cnpoRMrzJgNoF4k=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0/go.mod h1:+MkJVOR/rgGWe6xEVnjRSRCKhjM1KkpeaheqS9UHjM8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/login/go.mod
+++ b/login/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/chromedp/chromedp v0.14.2
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0
 )
 

--- a/login/go.sum
+++ b/login/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0 h1:WQcir+LsmAlaihnnRdLUiGefy2J+cnpoRMrzJgNoF4k=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0/go.mod h1:+MkJVOR/rgGWe6xEVnjRSRCKhjM1KkpeaheqS9UHjM8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/observability/go.mod
+++ b/observability/go.mod
@@ -3,7 +3,7 @@ module observability
 go 1.25
 
 require (
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da
 )
 

--- a/observability/go.sum
+++ b/observability/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da h1:ZONdEpB9vxj4xyJlQ1t3I/sIxkllrKu5fWadFL60nsA=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da/go.mod h1:1/HRPggC3loru3AB6GYQdMWP1bJhuCGZERD36GlLEw0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/production/single-host/go.mod
+++ b/production/single-host/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da
 )
 

--- a/production/single-host/go.sum
+++ b/production/single-host/go.sum
@@ -49,7 +49,9 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d h1:ZtA1sedVbEW7EW80Iz2GR3Ye6PwbJAJXjv7D74xG6HU=
+github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZSzM=
+github.com/chromedp/chromedp v0.14.2/go.mod h1:rHzAv60xDE7VNy/MYtTUrYreSc0ujt2O1/C3bzctYBo=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -79,6 +81,7 @@ github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.11 h1:AQvxbp830wPhHTqc1u7nzoLT+ZFxGY7emj5DR5DYFik=
+github.com/gabriel-vasile/mimetype v1.4.11/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 h1:iizUGZ9pEquQS5jTGkh4AqeeHCMbfbjeb0zMt0aEFzs=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -113,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da h1:ZONdEpB9vxj4xyJlQ1t3I/sIxkllrKu5fWadFL60nsA=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da/go.mod h1:1/HRPggC3loru3AB6GYQdMWP1bJhuCGZERD36GlLEw0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -160,7 +163,9 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tdewolff/minify/v2 v2.24.6 h1:GdScQWO9fJcMsR93SFWFvD3q3b4W4Uhf81VBYAiK8qk=
+github.com/tdewolff/minify/v2 v2.24.6/go.mod h1:0Ukj0CRpo/sW/nd8uZ4ccXaV1rEVIWA3dj8U7+Shhfw=
 github.com/tdewolff/parse/v2 v2.8.5 h1:ZmBiA/8Do5Rpk7bDye0jbbDUpXXbCdc3iah4VeUvwYU=
+github.com/tdewolff/parse/v2 v2.8.5/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
 github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
 github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/testcontainers/testcontainers-go v0.39.0 h1:uCUJ5tA+fcxbFAB0uP3pIK3EJ2IjjDUHFSZ1H1UxAts=
@@ -184,10 +189,14 @@ go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FK
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
+golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
+golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.30.0 h1:yznKA/E9zq54KzlzBEAWn1NXSQ8DIp/NYMy88xJjl4k=
+golang.org/x/text v0.30.0/go.mod h1:yDdHFIX9t+tORqspjENWgzaCVXgk0yYnYuSZ8UzzBVM=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/testing/01_basic/go.mod
+++ b/testing/01_basic/go.mod
@@ -3,7 +3,7 @@ module basic
 go 1.25
 
 require (
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0
 )
 

--- a/testing/01_basic/go.sum
+++ b/testing/01_basic/go.sum
@@ -49,7 +49,9 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d h1:ZtA1sedVbEW7EW80Iz2GR3Ye6PwbJAJXjv7D74xG6HU=
+github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZSzM=
+github.com/chromedp/chromedp v0.14.2/go.mod h1:rHzAv60xDE7VNy/MYtTUrYreSc0ujt2O1/C3bzctYBo=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -79,6 +81,7 @@ github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.11 h1:AQvxbp830wPhHTqc1u7nzoLT+ZFxGY7emj5DR5DYFik=
+github.com/gabriel-vasile/mimetype v1.4.11/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 h1:iizUGZ9pEquQS5jTGkh4AqeeHCMbfbjeb0zMt0aEFzs=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -113,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0 h1:WQcir+LsmAlaihnnRdLUiGefy2J+cnpoRMrzJgNoF4k=
 github.com/livetemplate/lvt v0.0.0-20251103195948-fbcd6dfae2d0/go.mod h1:+MkJVOR/rgGWe6xEVnjRSRCKhjM1KkpeaheqS9UHjM8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -160,7 +163,9 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tdewolff/minify/v2 v2.24.6 h1:GdScQWO9fJcMsR93SFWFvD3q3b4W4Uhf81VBYAiK8qk=
+github.com/tdewolff/minify/v2 v2.24.6/go.mod h1:0Ukj0CRpo/sW/nd8uZ4ccXaV1rEVIWA3dj8U7+Shhfw=
 github.com/tdewolff/parse/v2 v2.8.5 h1:ZmBiA/8Do5Rpk7bDye0jbbDUpXXbCdc3iah4VeUvwYU=
+github.com/tdewolff/parse/v2 v2.8.5/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
 github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
 github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/testcontainers/testcontainers-go v0.39.0 h1:uCUJ5tA+fcxbFAB0uP3pIK3EJ2IjjDUHFSZ1H1UxAts=
@@ -184,10 +189,14 @@ go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FK
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
+golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
+golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.30.0 h1:yznKA/E9zq54KzlzBEAWn1NXSQ8DIp/NYMy88xJjl4k=
+golang.org/x/text v0.30.0/go.mod h1:yDdHFIX9t+tORqspjENWgzaCVXgk0yYnYuSZ8UzzBVM=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/todos-components/go.mod
+++ b/todos-components/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/gorilla/websocket v1.5.3
 	github.com/livetemplate/components v0.0.0
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.6.0
 )
 

--- a/todos/go.mod
+++ b/todos/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/go-playground/validator/v10 v10.28.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d
 	modernc.org/sqlite v1.39.1
 )

--- a/todos/go.sum
+++ b/todos/go.sum
@@ -120,8 +120,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d h1:KKaaDPTlSCL/BEz5B+xowvXgOpl0kLpAdWZLIXL/2a0=
 github.com/livetemplate/lvt v0.0.0-20251130141940-9b94cde94e9d/go.mod h1:iwP3NZgs3EGXd6mTUAK3j4UENr7qhuUmAME44LoTExE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/trace-correlation/go.mod
+++ b/trace-correlation/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/livetemplate/livetemplate v0.7.0
+	github.com/livetemplate/livetemplate v0.7.4
 	github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da
 )
 

--- a/trace-correlation/go.sum
+++ b/trace-correlation/go.sum
@@ -116,8 +116,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.7.0 h1:ugpgI+MG/y3QV/moOLaL9A7wc7HVwFw3aeyN3OZ6e00=
-github.com/livetemplate/livetemplate v0.7.0/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
+github.com/livetemplate/livetemplate v0.7.4 h1:qrCFVNM014uhdcW+ZUQ5MqZdM9jKG66mN8PkxV866e0=
+github.com/livetemplate/livetemplate v0.7.4/go.mod h1:mTI76skBGEx4jD9pO52L9xBY4/ZDW4muAKWwXnupvtc=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da h1:ZONdEpB9vxj4xyJlQ1t3I/sIxkllrKu5fWadFL60nsA=
 github.com/livetemplate/lvt v0.0.0-20251103070549-7ffea37f50da/go.mod h1:1/HRPggC3loru3AB6GYQdMWP1bJhuCGZERD36GlLEw0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=


### PR DESCRIPTION
## Summary

Updates all examples to use `github.com/livetemplate/livetemplate` v0.7.4

## Key fixes in v0.7.4

- Fix null statics in append operations for empty→items transitions
- Ensure Range.Statics always populated for diff operations  
- Fix signature calculation for heterogeneous ranges

## Changes

- Updated 11 examples to v0.7.4
- Ran `go mod tidy` to update go.sum files

🤖 Generated with [Claude Code](https://claude.com/claude-code)