### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.26'
 
     - name: Run test script
       run: ./test-all.sh --skip-disabled
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.26'
 
     - name: Install dependencies
       working-directory: ${{ matrix.example }}
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.26'
 
     - name: Check dependencies
       working-directory: ${{ matrix.example }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livetemplate/examples
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/chromedp/chromedp v0.14.2


### PR DESCRIPTION
## Summary
- Upgrade Go to 1.26.0 in go.mod
- Update CI workflow Go versions to 1.26 (test.yml — all 3 jobs)

## Test plan
- [x] `go mod tidy` completes without errors
- [x] `go test ./...` passes for core examples (counter, chat, todos, login, avatar-upload, testing/01_basic)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)