### PR TITLE
feat: add patterns example app — Session 1 (scaffold + forms #1-7)

### DIFF
--- a/patterns/cross_handler_nav_test.go
+++ b/patterns/cross_handler_nav_test.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+// TestCrossHandlerNavigation verifies that SPA navigation between different
+// LiveTemplate handlers works correctly. Each pattern is a separate handler
+// with its own data-lvt-id, so navigating between them requires the client
+// to disconnect the old WebSocket and reconnect to the new handler.
+func TestCrossHandlerNavigation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	baseURL := e2etest.GetChromeTestURL(serverPort)
+
+	t.Run("Index_to_Pattern", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			// Start at the index page
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+
+			// Click on "Edit Row" link
+			chromedp.Click(`a[href="/patterns/forms/edit-row"]`, chromedp.ByQuery),
+
+			// Wait for the Edit Row page content to appear
+			e2etest.WaitForText(`h3`, "Edit Row", 10*time.Second),
+			chromedp.OuterHTML(`body`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Navigation from index to Edit Row failed: %v", err)
+		}
+		if !strings.Contains(html, "Joe Smith") {
+			t.Error("Edit Row content 'Joe Smith' not found after navigation")
+		}
+		if !strings.Contains(html, "Edit Row") {
+			t.Error("Edit Row heading not found after navigation")
+		}
+
+		// Verify URL was updated
+		var currentURL string
+		chromedp.Run(ctx, chromedp.Location(&currentURL))
+		if !strings.HasSuffix(currentURL, "/patterns/forms/edit-row") {
+			t.Errorf("Expected URL ending in /patterns/forms/edit-row, got %s", currentURL)
+		}
+	})
+
+	t.Run("Pattern_Back_to_Index", func(t *testing.T) {
+		// We should already be on the Edit Row page from the previous test
+		var html string
+		err := chromedp.Run(ctx,
+			// Click "Patterns" nav link to go back to index
+			chromedp.Click(`nav a[href="/"]`, chromedp.ByQuery),
+
+			// Wait for index page content
+			e2etest.WaitForText(`h2`, "LiveTemplate Patterns", 10*time.Second),
+			chromedp.OuterHTML(`body`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Navigation from pattern back to index failed: %v", err)
+		}
+		if !strings.Contains(html, "Forms &amp; Editing") {
+			t.Error("Index page category 'Forms & Editing' not found")
+		}
+
+		// Verify URL was updated back to root
+		var currentURL string
+		chromedp.Run(ctx, chromedp.Location(&currentURL))
+		if !strings.HasSuffix(currentURL, fmt.Sprintf(":%d/", serverPort)) {
+			t.Errorf("Expected URL ending in :%d/, got %s", serverPort, currentURL)
+		}
+	})
+
+	t.Run("Navigate_Between_Two_Patterns", func(t *testing.T) {
+		// Start fresh at index
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load index: %v", err)
+		}
+
+		// Navigate to Click To Edit
+		var html1 string
+		err = chromedp.Run(ctx,
+			chromedp.Click(`a[href="/patterns/forms/click-to-edit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Click To Edit", 10*time.Second),
+			chromedp.OuterHTML(`article`, &html1, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Navigation to Click To Edit failed: %v", err)
+		}
+		if !strings.Contains(html1, "john@example.com") {
+			t.Error("Click To Edit content not found")
+		}
+
+		// Navigate back to index via "Patterns" nav link
+		err = chromedp.Run(ctx,
+			chromedp.Click(`nav a[href="/"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h2`, "LiveTemplate Patterns", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Navigation back to index failed: %v", err)
+		}
+
+		// Now navigate to Bulk Update (different pattern)
+		var html2 string
+		err = chromedp.Run(ctx,
+			chromedp.Click(`a[href="/patterns/forms/bulk-update"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Bulk Update", 10*time.Second),
+			chromedp.OuterHTML(`article`, &html2, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Navigation to Bulk Update failed: %v", err)
+		}
+		if !strings.Contains(html2, "Joe Smith") {
+			t.Error("Bulk Update content not found")
+		}
+
+		// Verify no stale content from Click To Edit
+		if strings.Contains(html2, "john@example.com") {
+			t.Error("Stale Click To Edit content still present on Bulk Update page")
+		}
+	})
+
+	t.Run("Browser_Back_Button", func(t *testing.T) {
+		// Start fresh at index
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load index: %v", err)
+		}
+
+		// Navigate forward to Click To Edit
+		err = chromedp.Run(ctx,
+			chromedp.Click(`a[href="/patterns/forms/click-to-edit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Click To Edit", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Forward navigation failed: %v", err)
+		}
+
+		// Press browser Back button
+		err = chromedp.Run(ctx,
+			chromedp.NavigateBack(),
+			e2etest.WaitForText(`h2`, "LiveTemplate Patterns", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Back button navigation failed: %v", err)
+		}
+
+		// Verify we're on the index page
+		var html string
+		err = chromedp.Run(ctx,
+			chromedp.OuterHTML(`body`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read page after back: %v", err)
+		}
+		if !strings.Contains(html, "Forms &amp; Editing") {
+			t.Error("Index page content not found after back button")
+		}
+
+		// Press browser Forward button
+		err = chromedp.Run(ctx,
+			chromedp.NavigateForward(),
+			e2etest.WaitForText(`h3`, "Click To Edit", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Forward button navigation failed: %v", err)
+		}
+	})
+
+	t.Run("Title_Updates_On_Navigation", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load index: %v", err)
+		}
+
+		// Verify index title
+		var title string
+		chromedp.Run(ctx, chromedp.Title(&title))
+		if !strings.Contains(title, "LiveTemplate Patterns") {
+			t.Errorf("Expected index title to contain 'LiveTemplate Patterns', got %q", title)
+		}
+
+		// Navigate to Click To Edit
+		err = chromedp.Run(ctx,
+			chromedp.Click(`a[href="/patterns/forms/click-to-edit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Click To Edit", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Navigation failed: %v", err)
+		}
+
+		// Verify title updated
+		chromedp.Run(ctx, chromedp.Title(&title))
+		if !strings.Contains(title, "Click To Edit") {
+			t.Errorf("Expected title to contain 'Click To Edit', got %q", title)
+		}
+
+		// Navigate back and verify title restores
+		err = chromedp.Run(ctx,
+			chromedp.NavigateBack(),
+			e2etest.WaitForText(`h2`, "LiveTemplate Patterns", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Back navigation failed: %v", err)
+		}
+
+		chromedp.Run(ctx, chromedp.Title(&title))
+		if !strings.Contains(title, "LiveTemplate Patterns") {
+			t.Errorf("Expected title to restore to 'LiveTemplate Patterns', got %q", title)
+		}
+	})
+
+	t.Run("WebSocket_Works_After_Back_Button", func(t *testing.T) {
+		// Navigate to Reset Input, then back, then forward, then test WebSocket
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.Click(`a[href="/patterns/forms/reset-input"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Reset User Input", 10*time.Second),
+			e2etest.WaitForWebSocketReady(10*time.Second),
+			// Go back
+			chromedp.NavigateBack(),
+			e2etest.WaitForText(`h2`, "LiveTemplate Patterns", 10*time.Second),
+			// Go forward to Reset Input again
+			chromedp.NavigateForward(),
+			e2etest.WaitForText(`h3`, "Reset User Input", 10*time.Second),
+			e2etest.WaitForWebSocketReady(10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Back/forward navigation failed: %v", err)
+		}
+
+		// Verify WebSocket works by submitting a form
+		var html string
+		err = chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="message"]`, "After back-forward", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "After back-forward", 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Form submission after back/forward failed: %v", err)
+		}
+		if !strings.Contains(html, "After back-forward") {
+			t.Error("Message not found after back/forward navigation")
+		}
+	})
+
+	t.Run("WebSocket_Works_After_Navigation", func(t *testing.T) {
+		// Start fresh at index
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load index: %v", err)
+		}
+
+		// Navigate to Reset Input
+		err = chromedp.Run(ctx,
+			chromedp.Click(`a[href="/patterns/forms/reset-input"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Reset User Input", 10*time.Second),
+			// Wait for WebSocket to reconnect on the new handler
+			e2etest.WaitForWebSocketReady(10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Navigation to Reset Input failed: %v", err)
+		}
+
+		// Submit a form — this requires a working WebSocket connection
+		var html string
+		err = chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="message"]`, "Cross-handler test", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Cross-handler test", 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Form submission after cross-handler nav failed: %v", err)
+		}
+		if !strings.Contains(html, "Cross-handler test") {
+			t.Error("Submitted message not found — WebSocket not reconnected")
+		}
+	})
+}

--- a/patterns/data.go
+++ b/patterns/data.go
@@ -1,0 +1,125 @@
+package main
+
+// Contact represents a person in the demo data.
+type Contact struct {
+	ID    string
+	Name  string
+	Email string
+}
+
+// UserRow represents a user with an active status toggle.
+type UserRow struct {
+	ID     string
+	Name   string
+	Email  string
+	Active bool
+}
+
+// Item is a generic named item used across multiple patterns.
+type Item struct {
+	ID   string
+	Name string
+}
+
+func sampleContacts() []Contact {
+	return []Contact{
+		{ID: "1", Name: "Joe Smith", Email: "joe@smith.org"},
+		{ID: "2", Name: "Angie MacDowell", Email: "angie@macdowell.org"},
+		{ID: "3", Name: "Fuqua Tarkenton", Email: "fuqua@tarkenton.org"},
+		{ID: "4", Name: "Kim Yee", Email: "kim@yee.org"},
+	}
+}
+
+func sampleUsers() []UserRow {
+	return []UserRow{
+		{ID: "1", Name: "Joe Smith", Email: "joe@smith.org", Active: true},
+		{ID: "2", Name: "Angie MacDowell", Email: "angie@macdowell.org", Active: true},
+		{ID: "3", Name: "Fuqua Tarkenton", Email: "fuqua@tarkenton.org", Active: false},
+		{ID: "4", Name: "Kim Yee", Email: "kim@yee.org", Active: false},
+	}
+}
+
+// PatternLink describes a single pattern in the index page catalog.
+type PatternLink struct {
+	Name        string
+	Path        string
+	Description string
+	Implemented bool
+}
+
+// PatternCategory groups related patterns for the index page.
+type PatternCategory struct {
+	Name     string
+	Patterns []PatternLink
+}
+
+func allPatterns() []PatternCategory {
+	return []PatternCategory{
+		{
+			Name: "Forms & Editing",
+			Patterns: []PatternLink{
+				{Name: "Click To Edit", Path: "/patterns/forms/click-to-edit", Description: "Toggle between view and edit mode", Implemented: true},
+				{Name: "Edit Row", Path: "/patterns/forms/edit-row", Description: "Inline editing of table rows", Implemented: true},
+				{Name: "Inline Validation", Path: "/patterns/forms/inline-validation", Description: "Server-side field validation as you type", Implemented: true},
+				{Name: "Bulk Update", Path: "/patterns/forms/bulk-update", Description: "Batch checkbox operations", Implemented: true},
+				{Name: "Reset User Input", Path: "/patterns/forms/reset-input", Description: "Auto-clear forms after submission", Implemented: true},
+				{Name: "File Upload", Path: "/patterns/forms/file-upload", Description: "Standard and chunked file uploads", Implemented: true},
+				{Name: "Preserving File Inputs", Path: "/patterns/forms/preserve-inputs", Description: "Retain form values across re-renders", Implemented: true},
+			},
+		},
+		{
+			Name: "Lists & Data",
+			Patterns: []PatternLink{
+				{Name: "Delete Row", Path: "/patterns/lists/delete-row", Description: "Animated row removal"},
+				{Name: "Click To Load", Path: "/patterns/lists/click-to-load", Description: "Append-only pagination"},
+				{Name: "Infinite Scroll", Path: "/patterns/lists/infinite-scroll", Description: "Auto-load on scroll with IntersectionObserver"},
+				{Name: "Value Select", Path: "/patterns/lists/value-select", Description: "Cascading dependent selects"},
+			},
+		},
+		{
+			Name: "Search & Filtering",
+			Patterns: []PatternLink{
+				{Name: "Active Search", Path: "/patterns/search/active-search", Description: "Debounced live search"},
+				{Name: "URL-Preserved Filters", Path: "/patterns/search/url-filters", Description: "Bookmarkable filter state via query params"},
+			},
+		},
+		{
+			Name: "Loading & Progress",
+			Patterns: []PatternLink{
+				{Name: "Lazy Loading", Path: "/patterns/loading/lazy-loading", Description: "Load content after page render via server push"},
+				{Name: "Progress Bar", Path: "/patterns/loading/progress-bar", Description: "WebSocket-pushed progress updates"},
+				{Name: "Async Operations", Path: "/patterns/loading/async-operations", Description: "Loading/success/error state machine"},
+			},
+		},
+		{
+			Name: "Dialogs, Tabs & Navigation",
+			Patterns: []PatternLink{
+				{Name: "Modal Dialog", Path: "/patterns/navigation/modal-dialog", Description: "Native dialog with command/commandfor"},
+				{Name: "Confirm Dialog", Path: "/patterns/navigation/confirm-dialog", Description: "CSP-compliant confirmation flow"},
+				{Name: "Tabs (HATEOAS)", Path: "/patterns/navigation/tabs", Description: "Server-driven tabs via SPA navigation"},
+				{Name: "SPA Navigation", Path: "/patterns/navigation/spa-navigation", Description: "Auto link interception with pushState"},
+				{Name: "Keyboard Shortcuts", Path: "/patterns/navigation/keyboard-shortcuts", Description: "Global keyboard event binding"},
+			},
+		},
+		{
+			Name: "Visual Feedback",
+			Patterns: []PatternLink{
+				{Name: "Animations", Path: "/patterns/feedback/animations", Description: "Entry animations with lvt-fx:animate"},
+				{Name: "Loading States", Path: "/patterns/feedback/loading-states", Description: "Auto aria-busy and custom loading text"},
+				{Name: "Highlight on Change", Path: "/patterns/feedback/highlight", Description: "Visual flash on DOM updates"},
+				{Name: "Flash Messages", Path: "/patterns/feedback/flash-messages", Description: "Toast notifications via ctx.SetFlash"},
+			},
+		},
+		{
+			Name: "Real-Time & Multi-User",
+			Patterns: []PatternLink{
+				{Name: "Multi-User Sync", Path: "/patterns/realtime/multi-user-sync", Description: "Auto-sync across tabs via Sync() handler"},
+				{Name: "Broadcasting", Path: "/patterns/realtime/broadcasting", Description: "Cross-connection updates via BroadcastAction"},
+				{Name: "Presence Tracking", Path: "/patterns/realtime/presence", Description: "Explicit join/leave with shared state"},
+				{Name: "Reconnection Recovery", Path: "/patterns/realtime/reconnection", Description: "State persistence across disconnects"},
+				{Name: "Live Preview", Path: "/patterns/realtime/live-preview", Description: "Real-time input preview via Change()"},
+				{Name: "Server Push", Path: "/patterns/realtime/server-push", Description: "Background goroutine pushing updates"},
+			},
+		},
+	}
+}

--- a/patterns/handlers_forms.go
+++ b/patterns/handlers_forms.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -124,6 +125,7 @@ func (c *BulkUpdateController) BulkUpdate(state BulkUpdateState, ctx *livetempla
 	for i, user := range state.Users {
 		state.Users[i].Active = ctx.GetBool("active-" + user.ID)
 	}
+	ctx.SetFlash("success", fmt.Sprintf("Updated %d user(s)", len(state.Users)))
 	return state, nil
 }
 
@@ -166,26 +168,31 @@ func resetInputHandler(baseOpts []livetemplate.Option) http.Handler {
 
 type FileUploadController struct{}
 
-func (c *FileUploadController) Submit(state FileUploadState, ctx *livetemplate.Context) (FileUploadState, error) {
+func (c *FileUploadController) Upload(state FileUploadState, ctx *livetemplate.Context) (FileUploadState, error) {
 	for _, name := range []string{"document", "chunked-doc"} {
 		if ctx.HasUploads(name) {
 			entries := ctx.GetCompletedUploads(name)
 			if len(entries) > 0 {
-				state.UploadName = entries[0].ClientName
-				state.Uploaded = true
+				ctx.SetFlash("success", "Uploaded: "+entries[0].ClientName)
 				return state, nil
 			}
 		}
 	}
+	ctx.SetFlash("error", "No file selected")
 	return state, nil
 }
 
 func fileUploadHandler(baseOpts []livetemplate.Option) http.Handler {
 	opts := append(slices.Clone(baseOpts),
 		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/file-upload.tmpl"),
+		livetemplate.WithUpload("document", livetemplate.UploadConfig{
+			MaxFileSize: 10 << 20, // 10 MB
+			MaxEntries:  1,
+		}),
 		livetemplate.WithUpload("chunked-doc", livetemplate.UploadConfig{
 			MaxFileSize: 10 << 20, // 10 MB
 			MaxEntries:  1,
+			ChunkSize:   1024, // 1KB chunks — small so progress is visible for demo files
 		}),
 	)
 	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
@@ -205,12 +212,17 @@ func (c *PreserveInputsController) Submit(state PreserveInputsState, ctx *livete
 	if err := ctx.ValidateForm(); err != nil {
 		return state, err
 	}
+	ctx.SetFlash("success", "Saved: "+state.Name)
 	return state, nil
 }
 
 func preserveInputsHandler(baseOpts []livetemplate.Option) http.Handler {
 	opts := append(slices.Clone(baseOpts),
 		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/preserve-inputs.tmpl"),
+		livetemplate.WithUpload("attachment", livetemplate.UploadConfig{
+			MaxFileSize: 10 << 20, // 10 MB
+			MaxEntries:  1,
+		}),
 	)
 	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
 	return tmpl.Handle(&PreserveInputsController{}, livetemplate.AsState(&PreserveInputsState{

--- a/patterns/handlers_forms.go
+++ b/patterns/handlers_forms.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/livetemplate/livetemplate"
+)
+
+// --- Pattern #1: Click To Edit ---
+
+type ClickToEditController struct{}
+
+func (c *ClickToEditController) Edit(state ClickToEditState, ctx *livetemplate.Context) (ClickToEditState, error) {
+	state.Editing = true
+	return state, nil
+}
+
+func (c *ClickToEditController) Save(state ClickToEditState, ctx *livetemplate.Context) (ClickToEditState, error) {
+	state.FirstName = ctx.GetString("firstName")
+	state.LastName = ctx.GetString("lastName")
+	state.Email = ctx.GetString("email")
+	state.Editing = false
+	return state, nil
+}
+
+func (c *ClickToEditController) Cancel(state ClickToEditState, ctx *livetemplate.Context) (ClickToEditState, error) {
+	state.Editing = false
+	return state, nil
+}
+
+func clickToEditHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/click-to-edit.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ClickToEditController{}, livetemplate.AsState(&ClickToEditState{
+		Title:     "Click To Edit",
+		Category:  "Forms & Editing",
+		FirstName: "John",
+		LastName:  "Doe",
+		Email:     "john@example.com",
+	}))
+}
+
+// --- Pattern #2: Edit Row ---
+
+type EditRowController struct{}
+
+func (c *EditRowController) Edit(state EditRowState, ctx *livetemplate.Context) (EditRowState, error) {
+	state.EditingID = ctx.GetString("id")
+	return state, nil
+}
+
+func (c *EditRowController) Save(state EditRowState, ctx *livetemplate.Context) (EditRowState, error) {
+	id := ctx.GetString("id")
+	for i, contact := range state.Contacts {
+		if contact.ID == id {
+			state.Contacts[i].Name = ctx.GetString("name")
+			state.Contacts[i].Email = ctx.GetString("email")
+			break
+		}
+	}
+	state.EditingID = ""
+	return state, nil
+}
+
+func (c *EditRowController) Cancel(state EditRowState, ctx *livetemplate.Context) (EditRowState, error) {
+	state.EditingID = ""
+	return state, nil
+}
+
+func editRowHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/edit-row.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&EditRowController{}, livetemplate.AsState(&EditRowState{
+		Title:    "Edit Row",
+		Category: "Forms & Editing",
+		Contacts: sampleContacts(),
+	}))
+}
+
+// --- Pattern #3: Inline Validation ---
+
+type InlineValidationController struct{}
+
+func (c *InlineValidationController) Change(state InlineValidationState, ctx *livetemplate.Context) (InlineValidationState, error) {
+	if ctx.Has("email") {
+		state.Email = ctx.GetString("email")
+	}
+	if ctx.Has("username") {
+		state.Username = ctx.GetString("username")
+	}
+	_ = ctx.ValidateForm()
+	return state, nil
+}
+
+func (c *InlineValidationController) Submit(state InlineValidationState, ctx *livetemplate.Context) (InlineValidationState, error) {
+	if err := ctx.ValidateForm(); err != nil {
+		return state, err
+	}
+	state.Saved = true
+	return state, nil
+}
+
+func inlineValidationHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/inline-validation.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&InlineValidationController{}, livetemplate.AsState(&InlineValidationState{
+		Title:    "Inline Validation",
+		Category: "Forms & Editing",
+	}))
+}
+
+// --- Pattern #4: Bulk Update ---
+
+type BulkUpdateController struct{}
+
+func (c *BulkUpdateController) BulkUpdate(state BulkUpdateState, ctx *livetemplate.Context) (BulkUpdateState, error) {
+	for i, user := range state.Users {
+		state.Users[i].Active = ctx.GetBool("active-" + user.ID)
+	}
+	return state, nil
+}
+
+func bulkUpdateHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/bulk-update.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&BulkUpdateController{}, livetemplate.AsState(&BulkUpdateState{
+		Title:    "Bulk Update",
+		Category: "Forms & Editing",
+		Users:    sampleUsers(),
+	}))
+}
+
+// --- Pattern #5: Reset User Input ---
+
+type ResetInputController struct{}
+
+func (c *ResetInputController) Submit(state ResetInputState, ctx *livetemplate.Context) (ResetInputState, error) {
+	msg := ctx.GetString("message")
+	if msg != "" {
+		state.Messages = append(state.Messages, msg)
+	}
+	return state, nil
+}
+
+func resetInputHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/reset-input.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ResetInputController{}, livetemplate.AsState(&ResetInputState{
+		Title:    "Reset User Input",
+		Category: "Forms & Editing",
+	}))
+}
+
+// --- Pattern #6: File Upload ---
+
+type FileUploadController struct{}
+
+func (c *FileUploadController) Submit(state FileUploadState, ctx *livetemplate.Context) (FileUploadState, error) {
+	for _, name := range []string{"document", "chunked-doc"} {
+		if ctx.HasUploads(name) {
+			entries := ctx.GetCompletedUploads(name)
+			if len(entries) > 0 {
+				state.UploadName = entries[0].ClientName
+				state.Uploaded = true
+				return state, nil
+			}
+		}
+	}
+	return state, nil
+}
+
+func fileUploadHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/file-upload.tmpl"),
+		livetemplate.WithUpload("chunked-doc", livetemplate.UploadConfig{
+			MaxFileSize: 10 << 20, // 10 MB
+			MaxEntries:  1,
+		}),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&FileUploadController{}, livetemplate.AsState(&FileUploadState{
+		Title:    "File Upload",
+		Category: "Forms & Editing",
+	}))
+}
+
+// --- Pattern #7: Preserving File Inputs ---
+
+type PreserveInputsController struct{}
+
+func (c *PreserveInputsController) Submit(state PreserveInputsState, ctx *livetemplate.Context) (PreserveInputsState, error) {
+	state.Name = ctx.GetString("name")
+	state.Description = ctx.GetString("description")
+	if err := ctx.ValidateForm(); err != nil {
+		return state, err
+	}
+	return state, nil
+}
+
+func preserveInputsHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/forms/preserve-inputs.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&PreserveInputsController{}, livetemplate.AsState(&PreserveInputsState{
+		Title:    "Preserving File Inputs",
+		Category: "Forms & Editing",
+	}))
+}

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"slices"
+	"syscall"
+	"time"
+
+	"github.com/livetemplate/livetemplate"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+// IndexController serves the pattern catalog index page.
+type IndexController struct{}
+
+// IndexState holds the categorized pattern list for the index page.
+type IndexState struct {
+	Title      string
+	Category   string
+	Categories []PatternCategory
+}
+
+func indexHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/index.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&IndexController{}, livetemplate.AsState(&IndexState{
+		Title:      "LiveTemplate Patterns",
+		Categories: allPatterns(),
+	}))
+}
+
+func main() {
+	envConfig, err := livetemplate.LoadEnvConfig()
+	if err != nil {
+		slog.Error("Failed to load configuration", "error", err)
+		os.Exit(1)
+	}
+	if err := envConfig.Validate(); err != nil {
+		slog.Error("Invalid configuration", "error", err)
+		os.Exit(1)
+	}
+
+	var level slog.Level
+	switch envConfig.LogLevel {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
+	baseOpts := envConfig.ToOptions()
+
+	mux := http.NewServeMux()
+
+	// Index page
+	mux.Handle("/", indexHandler(baseOpts))
+
+	// Category: Forms & Editing (#1–#7)
+	mux.Handle("/patterns/forms/click-to-edit", clickToEditHandler(baseOpts))
+	mux.Handle("/patterns/forms/edit-row", editRowHandler(baseOpts))
+	mux.Handle("/patterns/forms/inline-validation", inlineValidationHandler(baseOpts))
+	mux.Handle("/patterns/forms/bulk-update", bulkUpdateHandler(baseOpts))
+	mux.Handle("/patterns/forms/reset-input", resetInputHandler(baseOpts))
+	mux.Handle("/patterns/forms/file-upload", fileUploadHandler(baseOpts))
+	mux.Handle("/patterns/forms/preserve-inputs", preserveInputsHandler(baseOpts))
+
+	// Client library and CSS (dev mode)
+	mux.HandleFunc("/livetemplate-client.js", e2etest.ServeClientLibrary)
+	mux.HandleFunc("/livetemplate.css", e2etest.ServeCSS)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	server := &http.Server{
+		Addr:         ":" + port,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("Patterns server starting", "url", "http://localhost:"+port)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("Server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-quit
+
+	shutdownTimeout := envConfig.ShutdownTimeout
+	if shutdownTimeout == 0 {
+		shutdownTimeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	slog.Info("Shutting down server...")
+	if err := server.Shutdown(ctx); err != nil {
+		slog.Error("Shutdown error", "error", err)
+	}
+	slog.Info("Shutdown complete")
+}

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -76,7 +76,13 @@ func main() {
 	mux.Handle("/patterns/forms/preserve-inputs", preserveInputsHandler(baseOpts))
 
 	// Client library and CSS (dev mode)
-	mux.HandleFunc("/livetemplate-client.js", e2etest.ServeClientLibrary)
+	if localClient := os.Getenv("LVT_LOCAL_CLIENT"); localClient != "" {
+		mux.HandleFunc("/livetemplate-client.js", func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, localClient)
+		})
+	} else {
+		mux.HandleFunc("/livetemplate-client.js", e2etest.ServeClientLibrary)
+	}
 	mux.HandleFunc("/livetemplate.css", e2etest.ServeCSS)
 
 	port := os.Getenv("PORT")

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -185,9 +185,9 @@ func TestClickToEdit(t *testing.T) {
 		if !strings.Contains(html, "john@example.com") {
 			t.Error("Default email not found")
 		}
-		// Should be in view mode — dl should be present, form should not
-		if !strings.Contains(html, "<dl>") {
-			t.Error("View mode <dl> not found")
+		// Should be in view mode — table should be present, form should not
+		if !strings.Contains(html, "<table>") {
+			t.Error("View mode table not found")
 		}
 	})
 
@@ -232,7 +232,7 @@ func TestClickToEdit(t *testing.T) {
 			chromedp.SendKeys(`input[name="email"]`, "jane@smith.org", chromedp.ByQuery),
 			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
 			// Wait for view mode to return
-			e2etest.WaitFor(`document.querySelector('dl') !== null`, 5*time.Second),
+			e2etest.WaitFor(`document.querySelector('article table') !== null`, 5*time.Second),
 			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
 		)
 		if err != nil {
@@ -257,7 +257,7 @@ func TestClickToEdit(t *testing.T) {
 			e2etest.WaitFor(`document.querySelector('input[name="firstName"]') !== null`, 5*time.Second),
 			// Cancel without saving
 			chromedp.Click(`button[name="cancel"]`, chromedp.ByQuery),
-			e2etest.WaitFor(`document.querySelector('dl') !== null`, 5*time.Second),
+			e2etest.WaitFor(`document.querySelector('article table') !== null`, 5*time.Second),
 			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
 		)
 		if err != nil {

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1,0 +1,759 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	e2etest "github.com/livetemplate/lvt/testing"
+)
+
+func TestMain(m *testing.M) {
+	e2etest.CleanupChromeContainers()
+	code := m.Run()
+	e2etest.CleanupChromeContainers()
+	os.Exit(code)
+}
+
+// setupTest starts the server and Docker Chrome, returning the chromedp context
+// and the server port. Cleanup is handled via t.Cleanup.
+func setupTest(t *testing.T) (context.Context, context.CancelFunc, int) {
+	t.Helper()
+
+	serverPort, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port for server: %v", err)
+	}
+
+	debugPort, err := e2etest.GetFreePort()
+	if err != nil {
+		t.Fatalf("Failed to get free port for Chrome: %v", err)
+	}
+
+	serverCmd := e2etest.StartTestServer(t, ".", serverPort)
+	t.Cleanup(func() {
+		if serverCmd != nil && serverCmd.Process != nil {
+			serverCmd.Process.Kill()
+		}
+	})
+
+	chromeCmd := e2etest.StartDockerChrome(t, debugPort)
+	_ = chromeCmd
+	t.Cleanup(func() {
+		e2etest.StopDockerChrome(t, debugPort)
+	})
+
+	chromeURL := fmt.Sprintf("http://localhost:%d", debugPort)
+	allocCtx, allocCancel := chromedp.NewRemoteAllocator(context.Background(), chromeURL)
+	t.Cleanup(allocCancel)
+
+	ctx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(t.Logf))
+	t.Cleanup(cancel)
+
+	ctx, cancel = context.WithTimeout(ctx, 120*time.Second)
+
+	return ctx, cancel, serverPort
+}
+
+// uiStandardsJS is the JavaScript snippet for UI standards validation.
+const uiStandardsJS = `(() => {
+	const v = [];
+	['onclick','onchange','oninput','onsubmit','onkeydown','onkeyup'].forEach(h => {
+		document.querySelectorAll('[' + h + ']').forEach(el => v.push('inline ' + h + ' on <' + el.tagName.toLowerCase() + '>'));
+	});
+	document.querySelectorAll('[style]').forEach(el => {
+		if (el.tagName !== 'INS' && el.tagName !== 'DEL' && !el.closest('[data-modal]') && !el.closest('[data-lvt-toast-stack]'))
+			v.push('inline style on <' + el.tagName.toLowerCase() + '>');
+	});
+	if (!document.querySelector('meta[name="color-scheme"]')) v.push('missing color-scheme meta');
+	if (document.documentElement.lang !== 'en') v.push('missing lang=en');
+	const c = document.querySelector('.container');
+	if (c && c.offsetWidth > 700) v.push('container too wide: ' + c.offsetWidth + 'px');
+	return v.join('; ');
+})()`
+
+// runUIStandards validates CSP compliance and meta tags.
+func runUIStandards(t *testing.T, ctx context.Context) {
+	t.Helper()
+	var violations string
+	err := chromedp.Run(ctx,
+		chromedp.Evaluate(uiStandardsJS, &violations),
+	)
+	if err != nil {
+		t.Fatalf("UI standards check failed: %v", err)
+	}
+	if violations != "" {
+		t.Errorf("UI standard violations: %s", violations)
+	}
+}
+
+// runUIStandardsWithPico validates CSP compliance, meta tags, AND Pico CSS
+// conventions (input+button must be inside fieldset[role="group"]).
+// Use this for pages with inline forms. For pages with vertical labeled forms,
+// use runUIStandards (the fieldset[role="group"] rule doesn't apply to vertical forms).
+func runUIStandardsWithPico(t *testing.T, ctx context.Context) {
+	t.Helper()
+	runUIStandards(t, ctx)
+	if err := chromedp.Run(ctx, e2etest.ValidatePicoCSS()); err != nil {
+		t.Errorf("Pico CSS check failed: %v", err)
+	}
+}
+
+// --- Index Page ---
+
+func TestIndexPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(e2etest.GetChromeTestURL(serverPort)),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`body`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "LiveTemplate Patterns") {
+			t.Error("Page title not found")
+		}
+		if !strings.Contains(html, "Forms &amp; Editing") {
+			t.Error("Forms & Editing category not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Pattern index page — heading, 7 category cards with pattern links and descriptions")
+	})
+
+	t.Run("Pattern_Links", func(t *testing.T) {
+		var count int
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelectorAll('a[href^="/patterns/forms/"]').length`, &count),
+		)
+		if err != nil {
+			t.Fatalf("Failed to count pattern links: %v", err)
+		}
+		if count != 7 {
+			t.Errorf("Expected 7 Forms pattern links, got %d", count)
+		}
+	})
+}
+
+// --- Pattern #1: Click To Edit ---
+
+func TestClickToEdit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/click-to-edit"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h3`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "John") {
+			t.Error("Default first name 'John' not found")
+		}
+		if !strings.Contains(html, "john@example.com") {
+			t.Error("Default email not found")
+		}
+		// Should be in view mode — dl should be present, form should not
+		if !strings.Contains(html, "<dl>") {
+			t.Error("View mode <dl> not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Click To Edit — view mode with name/email displayed and Edit button")
+	})
+
+	t.Run("Edit_Mode", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="edit"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('input[name="firstName"]') !== null`, 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to enter edit mode: %v", err)
+		}
+		if !strings.Contains(html, `name="firstName"`) {
+			t.Error("Edit form firstName input not found")
+		}
+		if !strings.Contains(html, `name="save"`) {
+			t.Error("Save button not found")
+		}
+		if !strings.Contains(html, `name="cancel"`) {
+			t.Error("Cancel button not found")
+		}
+	})
+
+	t.Run("Save", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			// Clear and fill fields
+			chromedp.Clear(`input[name="firstName"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="firstName"]`, "Jane", chromedp.ByQuery),
+			chromedp.Clear(`input[name="lastName"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="lastName"]`, "Smith", chromedp.ByQuery),
+			chromedp.Clear(`input[name="email"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="email"]`, "jane@smith.org", chromedp.ByQuery),
+			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
+			// Wait for view mode to return
+			e2etest.WaitFor(`document.querySelector('dl') !== null`, 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to save: %v", err)
+		}
+		if !strings.Contains(html, "Jane") {
+			t.Error("Updated first name 'Jane' not found")
+		}
+		if !strings.Contains(html, "Smith") {
+			t.Error("Updated last name 'Smith' not found")
+		}
+		if !strings.Contains(html, "jane@smith.org") {
+			t.Error("Updated email not found")
+		}
+	})
+
+	t.Run("Cancel", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			// Enter edit mode
+			chromedp.Click(`button[name="edit"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('input[name="firstName"]') !== null`, 5*time.Second),
+			// Cancel without saving
+			chromedp.Click(`button[name="cancel"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('dl') !== null`, 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to cancel: %v", err)
+		}
+		// Should still have the saved values from previous test
+		if !strings.Contains(html, "Jane") {
+			t.Error("First name should still be 'Jane' after cancel")
+		}
+	})
+}
+
+// --- Pattern #2: Edit Row ---
+
+func TestEditRow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/edit-row"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "Joe Smith") {
+			t.Error("Contact 'Joe Smith' not found")
+		}
+		if !strings.Contains(html, "Kim Yee") {
+			t.Error("Contact 'Kim Yee' not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Edit Row — table with 4 contacts, each with name/email and Edit button")
+	})
+
+	t.Run("Edit_Row", func(t *testing.T) {
+		// Click Edit on the first row
+		err := chromedp.Run(ctx,
+			chromedp.Click(`tr[data-key="1"] button[name="edit"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('tr[data-key="1"] input[name="name"]') !== null`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to enter edit mode for row 1: %v", err)
+		}
+
+		// Verify the edit form has the correct values
+		var nameVal, emailVal string
+		err = chromedp.Run(ctx,
+			chromedp.Value(`tr[data-key="1"] input[name="name"]`, &nameVal, chromedp.ByQuery),
+			chromedp.Value(`tr[data-key="1"] input[name="email"]`, &emailVal, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read input values: %v", err)
+		}
+		if nameVal != "Joe Smith" {
+			t.Errorf("Expected name 'Joe Smith', got %q", nameVal)
+		}
+		if emailVal != "joe@smith.org" {
+			t.Errorf("Expected email 'joe@smith.org', got %q", emailVal)
+		}
+	})
+
+	t.Run("Save_Row", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Clear(`tr[data-key="1"] input[name="name"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`tr[data-key="1"] input[name="name"]`, "Joseph Smith", chromedp.ByQuery),
+			chromedp.Click(`tr[data-key="1"] button[name="save"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`tr[data-key="1"]`, "Joseph Smith", 5*time.Second),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to save row: %v", err)
+		}
+		if !strings.Contains(html, "Joseph Smith") {
+			t.Error("Updated name 'Joseph Smith' not found")
+		}
+		// Verify other rows are unaffected
+		if !strings.Contains(html, "Angie MacDowell") {
+			t.Error("Other contact 'Angie MacDowell' should still be present")
+		}
+		if !strings.Contains(html, "Kim Yee") {
+			t.Error("Other contact 'Kim Yee' should still be present")
+		}
+	})
+
+	t.Run("Cancel_Edit", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			// Edit row 2
+			chromedp.Click(`tr[data-key="2"] button[name="edit"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('tr[data-key="2"] input[name="name"]') !== null`, 5*time.Second),
+			// Cancel
+			chromedp.Click(`tr[data-key="2"] button[name="cancel"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('tr[data-key="2"] input[name="name"]') === null`, 5*time.Second),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to cancel edit: %v", err)
+		}
+		if !strings.Contains(html, "Angie MacDowell") {
+			t.Error("Contact 'Angie MacDowell' should remain unchanged after cancel")
+		}
+	})
+}
+
+// --- Pattern #3: Inline Validation ---
+
+func TestInlineValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/inline-validation"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h3`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "Inline Validation") {
+			t.Error("Page heading not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandards(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Inline Validation — email and username inputs with submit button, no errors shown yet")
+	})
+
+	t.Run("Valid_Submit", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="email"]`, "test@example.com", chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="username"]`, "testuser", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Saved successfully", 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to submit valid form: %v", err)
+		}
+		if !strings.Contains(html, "Saved successfully") {
+			t.Error("Success message not found")
+		}
+	})
+}
+
+// --- Pattern #4: Bulk Update ---
+
+func TestBulkUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/bulk-update"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "Joe Smith") {
+			t.Error("User 'Joe Smith' not found")
+		}
+		// Verify initial checkbox states (users 1,2 active; 3,4 inactive)
+		var checked1, checked3 bool
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('input[name="active-1"]').checked`, &checked1),
+			chromedp.Evaluate(`document.querySelector('input[name="active-3"]').checked`, &checked3),
+		)
+		if err != nil {
+			t.Fatalf("Failed to check checkbox states: %v", err)
+		}
+		if !checked1 {
+			t.Error("User 1 should be active initially")
+		}
+		if checked3 {
+			t.Error("User 3 should be inactive initially")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Bulk Update — table with 4 users, checkboxes for active status, Update button")
+	})
+
+	t.Run("Toggle_And_Update", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			// Uncheck user 1, check user 3
+			chromedp.Click(`input[name="active-1"]`, chromedp.ByQuery),
+			chromedp.Click(`input[name="active-3"]`, chromedp.ByQuery),
+			// Click Update
+			chromedp.Click(`button[name="bulkUpdate"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`true`, 2*time.Second), // Wait for re-render
+		)
+		if err != nil {
+			t.Fatalf("Failed to toggle and update: %v", err)
+		}
+
+		// Verify new checkbox states
+		var checked1, checked2, checked3, checked4 bool
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('input[name="active-1"]').checked`, &checked1),
+			chromedp.Evaluate(`document.querySelector('input[name="active-2"]').checked`, &checked2),
+			chromedp.Evaluate(`document.querySelector('input[name="active-3"]').checked`, &checked3),
+			chromedp.Evaluate(`document.querySelector('input[name="active-4"]').checked`, &checked4),
+		)
+		if err != nil {
+			t.Fatalf("Failed to verify checkbox states: %v", err)
+		}
+		if checked1 {
+			t.Error("User 1 should now be inactive")
+		}
+		if !checked2 {
+			t.Error("User 2 should still be active")
+		}
+		if !checked3 {
+			t.Error("User 3 should now be active")
+		}
+		if checked4 {
+			t.Error("User 4 should still be inactive")
+		}
+	})
+}
+
+// --- Pattern #5: Reset User Input ---
+
+func TestResetInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/reset-input"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h3`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "Reset User Input") {
+			t.Error("Page heading not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Reset User Input — message input with Send button, info text about auto-clear")
+	})
+
+	t.Run("Submit_Message", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="message"]`, "Hello World", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Hello World", 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to submit message: %v", err)
+		}
+		if !strings.Contains(html, "Hello World") {
+			t.Error("Submitted message not found")
+		}
+	})
+
+	t.Run("Form_Auto_Reset", func(t *testing.T) {
+		// After submission, the input should be cleared
+		var inputVal string
+		err := chromedp.Run(ctx,
+			chromedp.Value(`input[name="message"]`, &inputVal, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read input value: %v", err)
+		}
+		if inputVal != "" {
+			t.Errorf("Input should be empty after submit, got %q", inputVal)
+		}
+	})
+
+	t.Run("Multiple_Messages", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="message"]`, "Second message", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Second message", 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to submit second message: %v", err)
+		}
+		// Both messages should be present
+		if !strings.Contains(html, "Hello World") {
+			t.Error("First message 'Hello World' should still be present")
+		}
+		if !strings.Contains(html, "Second message") {
+			t.Error("Second message not found")
+		}
+	})
+}
+
+// --- Pattern #6: File Upload ---
+
+func TestFileUpload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/file-upload"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h3`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "File Upload") {
+			t.Error("Page heading not found")
+		}
+		if !strings.Contains(html, "Tier 1") {
+			t.Error("Tier 1 section not found")
+		}
+		if !strings.Contains(html, "Tier 2") {
+			t.Error("Tier 2 section not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandardsWithPico(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "File Upload — two sections: Tier 1 standard HTML upload and Tier 2 chunked upload, each with file input and Upload button")
+	})
+
+	t.Run("Tier1_Upload", func(t *testing.T) {
+		// Verify the Tier 1 multipart form has correct attributes.
+		// Full upload E2E testing is covered by the avatar-upload example.
+		// Here we verify the form structure is correct for multipart upload.
+		var enctype string
+		var hasFileInput bool
+		err := chromedp.Run(ctx,
+			chromedp.AttributeValue(`form[enctype]`, "enctype", &enctype, nil, chromedp.ByQuery),
+			chromedp.Evaluate(`document.querySelector('input[name="document"][type="file"]') !== null`, &hasFileInput),
+		)
+		if err != nil {
+			t.Fatalf("Failed to verify form structure: %v", err)
+		}
+		if enctype != "multipart/form-data" {
+			t.Errorf("Expected enctype='multipart/form-data', got %q", enctype)
+		}
+		if !hasFileInput {
+			t.Error("File input 'document' not found")
+		}
+
+		// Verify the Tier 2 chunked upload input has lvt-upload attribute
+		var hasLvtUpload bool
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('input[lvt-upload="chunked-doc"]') !== null`, &hasLvtUpload),
+		)
+		if err != nil {
+			t.Fatalf("Failed to verify Tier 2 upload: %v", err)
+		}
+		if !hasLvtUpload {
+			t.Error("Tier 2 lvt-upload input not found")
+		}
+	})
+}
+
+// --- Pattern #7: Preserving File Inputs ---
+
+func TestPreserveInputs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/forms/preserve-inputs"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h3`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, "Preserving Form Inputs") {
+			t.Error("Page heading not found")
+		}
+		if !strings.Contains(html, `lvt-form:preserve`) {
+			t.Error("lvt-form:preserve attribute not found")
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		runUIStandards(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Preserving Form Inputs — name input, description textarea, file attachment input, submit button")
+	})
+
+	t.Run("Submit_Valid", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="name"]`, "Test Name", chromedp.ByQuery),
+			chromedp.SendKeys(`textarea[name="description"]`, "Test Description", chromedp.ByQuery),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`true`, 3*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to submit valid form: %v", err)
+		}
+		// Form should preserve values via lvt-form:preserve
+		var nameVal string
+		err = chromedp.Run(ctx,
+			chromedp.Value(`input[name="name"]`, &nameVal, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read name value: %v", err)
+		}
+		if nameVal != "Test Name" {
+			t.Errorf("Name field should be preserved, got %q", nameVal)
+		}
+	})
+}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -103,6 +103,22 @@ func runUIStandardsWithPico(t *testing.T, ctx context.Context) {
 	}
 }
 
+// attachFileViaDataTransfer sets a File on the given file input using the
+// DataTransfer API. chromedp.SetUploadFiles cannot be used with Docker
+// Chrome because the container has no access to host filesystem paths.
+func attachFileViaDataTransfer(inputSelector, filename, content, mimeType string) chromedp.Action {
+	script := fmt.Sprintf(`
+		(() => {
+			const file = new File([%q], %q, {type: %q});
+			const input = document.querySelector(%q);
+			const dt = new DataTransfer();
+			dt.items.add(file);
+			input.files = dt.files;
+		})()
+	`, content, filename, mimeType, inputSelector)
+	return chromedp.Evaluate(script, nil)
+}
+
 // --- Index Page ---
 
 func TestIndexPage(t *testing.T) {
@@ -495,7 +511,8 @@ func TestBulkUpdate(t *testing.T) {
 			chromedp.Click(`input[name="active-3"]`, chromedp.ByQuery),
 			// Click Update
 			chromedp.Click(`button[name="bulkUpdate"]`, chromedp.ByQuery),
-			e2etest.WaitFor(`true`, 2*time.Second), // Wait for re-render
+			// Wait for flash message (FlashTag renders as <output data-flash>)
+			e2etest.WaitForText(`output[data-flash]`, "Updated", 5*time.Second),
 		)
 		if err != nil {
 			t.Fatalf("Failed to toggle and update: %v", err)
@@ -658,15 +675,44 @@ func TestFileUpload(t *testing.T) {
 		e2etest.ValidateScreenshotWithLLM(t, ctx, "File Upload — two sections: Tier 1 standard HTML upload and Tier 2 chunked upload, each with file input and Upload button")
 	})
 
-	t.Run("Tier1_Upload", func(t *testing.T) {
-		// Verify the Tier 1 multipart form has correct attributes.
-		// Full upload E2E testing is covered by the avatar-upload example.
-		// Here we verify the form structure is correct for multipart upload.
+	t.Run("Submit_Without_File", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.Click(`button[name="upload"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "No file selected", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("No-file error flash not shown: %v", err)
+		}
+	})
+
+	t.Run("Tier1_Upload_With_File", func(t *testing.T) {
+		// Upload a file via Tier 1 (standard multipart form).
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`input[name="document"]`, chromedp.ByQuery),
+			attachFileViaDataTransfer(`input[name="document"]`, "hello.txt", "hello world", "text/plain"),
+			chromedp.Click(`button[name="upload"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash]`, "Uploaded: hello.txt", 10*time.Second),
+		)
+		if err != nil {
+			var debugHTML string
+			_ = chromedp.Run(ctx, chromedp.OuterHTML(`body`, &debugHTML, chromedp.ByQuery))
+			t.Logf("Page HTML at failure:\n%s", debugHTML)
+			t.Fatalf("Tier 1 upload failed: %v", err)
+		}
+	})
+
+	t.Run("Form_Structure", func(t *testing.T) {
+		// Verify both Tier 1 and Tier 2 upload forms are present
 		var enctype string
-		var hasFileInput bool
+		var hasFileInput, hasLvtUpload bool
 		err := chromedp.Run(ctx,
 			chromedp.AttributeValue(`form[enctype]`, "enctype", &enctype, nil, chromedp.ByQuery),
 			chromedp.Evaluate(`document.querySelector('input[name="document"][type="file"]') !== null`, &hasFileInput),
+			chromedp.Evaluate(`document.querySelector('input[lvt-upload="chunked-doc"]') !== null`, &hasLvtUpload),
 		)
 		if err != nil {
 			t.Fatalf("Failed to verify form structure: %v", err)
@@ -675,16 +721,7 @@ func TestFileUpload(t *testing.T) {
 			t.Errorf("Expected enctype='multipart/form-data', got %q", enctype)
 		}
 		if !hasFileInput {
-			t.Error("File input 'document' not found")
-		}
-
-		// Verify the Tier 2 chunked upload input has lvt-upload attribute
-		var hasLvtUpload bool
-		err = chromedp.Run(ctx,
-			chromedp.Evaluate(`document.querySelector('input[lvt-upload="chunked-doc"]') !== null`, &hasLvtUpload),
-		)
-		if err != nil {
-			t.Fatalf("Failed to verify Tier 2 upload: %v", err)
+			t.Error("Tier 1 file input not found")
 		}
 		if !hasLvtUpload {
 			t.Error("Tier 2 lvt-upload input not found")
@@ -732,28 +769,76 @@ func TestPreserveInputs(t *testing.T) {
 		e2etest.ValidateScreenshotWithLLM(t, ctx, "Preserving Form Inputs — name input, description textarea, file attachment input, submit button")
 	})
 
-	t.Run("Submit_Valid", func(t *testing.T) {
-		var html string
+	t.Run("Submit_Shows_Flash", func(t *testing.T) {
 		err := chromedp.Run(ctx,
 			chromedp.SendKeys(`input[name="name"]`, "Test Name", chromedp.ByQuery),
 			chromedp.SendKeys(`textarea[name="description"]`, "Test Description", chromedp.ByQuery),
 			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
-			e2etest.WaitFor(`true`, 3*time.Second),
-			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Saved: Test Name", 5*time.Second),
 		)
 		if err != nil {
-			t.Fatalf("Failed to submit valid form: %v", err)
+			t.Fatalf("Failed to submit or flash not shown: %v", err)
 		}
-		// Form should preserve values via lvt-form:preserve
+	})
+
+	t.Run("Form_Values_Preserved_After_Submit", func(t *testing.T) {
+		// After successful submit with lvt-form:preserve, form values
+		// should NOT be cleared (unlike normal forms which auto-reset).
+		var nameVal, descVal string
+		err := chromedp.Run(ctx,
+			chromedp.Value(`input[name="name"]`, &nameVal, chromedp.ByQuery),
+			chromedp.Value(`textarea[name="description"]`, &descVal, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read form values: %v", err)
+		}
+		if nameVal != "Test Name" {
+			t.Errorf("Name should be preserved after submit, got %q", nameVal)
+		}
+		if descVal != "Test Description" {
+			t.Errorf("Description should be preserved after submit, got %q", descVal)
+		}
+	})
+
+	t.Run("Values_Survive_Rerender", func(t *testing.T) {
+		// Submit again — triggers a re-render. Form values should survive
+		// because lvt-form:preserve prevents the client from overwriting
+		// input values during DOM patching.
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`article`, "Saved: Test Name", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Second submit failed: %v", err)
+		}
+
 		var nameVal string
 		err = chromedp.Run(ctx,
 			chromedp.Value(`input[name="name"]`, &nameVal, chromedp.ByQuery),
 		)
 		if err != nil {
-			t.Fatalf("Failed to read name value: %v", err)
+			t.Fatalf("Failed to read name after re-render: %v", err)
 		}
 		if nameVal != "Test Name" {
-			t.Errorf("Name field should be preserved, got %q", nameVal)
+			t.Errorf("Name should survive re-render with lvt-form:preserve, got %q", nameVal)
+		}
+	})
+
+	t.Run("Submit_With_File_Attached", func(t *testing.T) {
+		// Regression: text fields must reach the server even when the
+		// HTTP multipart path is taken (file attached).
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`input[name="name"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="name"]`, "WithFile Name", chromedp.ByQuery),
+			chromedp.SendKeys(`textarea[name="description"]`, "With File Description", chromedp.ByQuery),
+			attachFileViaDataTransfer(`input[name="attachment"]`, "test.txt", "test content", "text/plain"),
+			chromedp.Click(`button[type="submit"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash]`, "Saved: WithFile Name", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Submit with file attached failed: %v", err)
 		}
 	})
 }

--- a/patterns/state_forms.go
+++ b/patterns/state_forms.go
@@ -1,0 +1,58 @@
+package main
+
+// ClickToEditState holds the state for the Click To Edit pattern (#1).
+type ClickToEditState struct {
+	Title     string
+	Category  string
+	FirstName string
+	LastName  string
+	Email     string
+	Editing   bool
+}
+
+// EditRowState holds the state for the Edit Row pattern (#2).
+type EditRowState struct {
+	Title     string
+	Category  string
+	Contacts  []Contact
+	EditingID string
+}
+
+// InlineValidationState holds the state for the Inline Validation pattern (#3).
+type InlineValidationState struct {
+	Title    string
+	Category string
+	Email    string
+	Username string
+	Saved    bool
+}
+
+// BulkUpdateState holds the state for the Bulk Update pattern (#4).
+type BulkUpdateState struct {
+	Title    string
+	Category string
+	Users    []UserRow
+}
+
+// ResetInputState holds the state for the Reset User Input pattern (#5).
+type ResetInputState struct {
+	Title    string
+	Category string
+	Messages []string
+}
+
+// FileUploadState holds the state for the File Upload pattern (#6).
+type FileUploadState struct {
+	Title      string
+	Category   string
+	UploadName string
+	Uploaded   bool
+}
+
+// PreserveInputsState holds the state for the Preserving File Inputs pattern (#7).
+type PreserveInputsState struct {
+	Title       string
+	Category    string
+	Name        string
+	Description string
+}

--- a/patterns/state_forms.go
+++ b/patterns/state_forms.go
@@ -43,10 +43,8 @@ type ResetInputState struct {
 
 // FileUploadState holds the state for the File Upload pattern (#6).
 type FileUploadState struct {
-	Title      string
-	Category   string
-	UploadName string
-	Uploaded   bool
+	Title    string
+	Category string
 }
 
 // PreserveInputsState holds the state for the Preserving File Inputs pattern (#7).

--- a/patterns/templates/forms/bulk-update.tmpl
+++ b/patterns/templates/forms/bulk-update.tmpl
@@ -16,5 +16,6 @@
         </table>
         <button name="bulkUpdate">Update</button>
     </form>
+    {{.lvt.FlashTag "success"}}
 </article>
 {{end}}

--- a/patterns/templates/forms/bulk-update.tmpl
+++ b/patterns/templates/forms/bulk-update.tmpl
@@ -1,0 +1,20 @@
+{{define "content"}}
+<article>
+    <h3>Bulk Update</h3>
+    <form method="POST">
+        <table>
+            <thead><tr><th>Name</th><th>Email</th><th>Active</th></tr></thead>
+            <tbody>
+            {{range .Users}}
+            <tr data-key="{{.ID}}">
+                <td>{{.Name}}</td>
+                <td>{{.Email}}</td>
+                <td><input type="checkbox" name="active-{{.ID}}" {{if .Active}}checked{{end}}></td>
+            </tr>
+            {{end}}
+            </tbody>
+        </table>
+        <button name="bulkUpdate">Update</button>
+    </form>
+</article>
+{{end}}

--- a/patterns/templates/forms/click-to-edit.tmpl
+++ b/patterns/templates/forms/click-to-edit.tmpl
@@ -1,0 +1,29 @@
+{{define "content"}}
+<article>
+    <h3>Click To Edit</h3>
+    {{if .Editing}}
+    <form method="POST">
+        <label>First Name
+            <input name="firstName" value="{{.FirstName}}" required>
+        </label>
+        <label>Last Name
+            <input name="lastName" value="{{.LastName}}" required>
+        </label>
+        <label>Email
+            <input name="email" type="email" value="{{.Email}}" required>
+        </label>
+        <fieldset role="group">
+            <button name="save">Save</button>
+            <button name="cancel" class="secondary">Cancel</button>
+        </fieldset>
+    </form>
+    {{else}}
+    <dl>
+        <dt>First Name</dt><dd>{{.FirstName}}</dd>
+        <dt>Last Name</dt><dd>{{.LastName}}</dd>
+        <dt>Email</dt><dd>{{.Email}}</dd>
+    </dl>
+    <button name="edit">Edit</button>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/forms/click-to-edit.tmpl
+++ b/patterns/templates/forms/click-to-edit.tmpl
@@ -18,12 +18,14 @@
         </fieldset>
     </form>
     {{else}}
-    <dl>
-        <dt>First Name</dt><dd>{{.FirstName}}</dd>
-        <dt>Last Name</dt><dd>{{.LastName}}</dd>
-        <dt>Email</dt><dd>{{.Email}}</dd>
-    </dl>
-    <button name="edit">Edit</button>
+    <table>
+        <tbody>
+            <tr><th>First Name</th><td>{{.FirstName}}</td></tr>
+            <tr><th>Last Name</th><td>{{.LastName}}</td></tr>
+            <tr><th>Email</th><td>{{.Email}}</td></tr>
+        </tbody>
+    </table>
+    <button name="edit" class="outline">Edit</button>
     {{end}}
 </article>
 {{end}}

--- a/patterns/templates/forms/edit-row.tmpl
+++ b/patterns/templates/forms/edit-row.tmpl
@@ -1,0 +1,36 @@
+{{define "content"}}
+<article>
+    <h3>Edit Row</h3>
+    <table>
+        <thead><tr><th>Name</th><th>Email</th><th></th></tr></thead>
+        <tbody>
+        {{range .Contacts}}
+        <tr data-key="{{.ID}}">
+            {{if eq $.EditingID .ID}}
+            <td colspan="3">
+                <form method="POST" class="inline">
+                    <input type="hidden" name="id" value="{{.ID}}">
+                    <fieldset role="group">
+                        <input name="name" value="{{.Name}}">
+                        <input name="email" value="{{.Email}}">
+                        <button name="save" class="compact">Save</button>
+                        <button name="cancel" class="compact secondary">Cancel</button>
+                    </fieldset>
+                </form>
+            </td>
+            {{else}}
+            <td>{{.Name}}</td>
+            <td>{{.Email}}</td>
+            <td>
+                <form method="POST" class="inline">
+                    <input type="hidden" name="id" value="{{.ID}}">
+                    <button name="edit" class="compact secondary outline">Edit</button>
+                </form>
+            </td>
+            {{end}}
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+</article>
+{{end}}

--- a/patterns/templates/forms/file-upload.tmpl
+++ b/patterns/templates/forms/file-upload.tmpl
@@ -1,0 +1,21 @@
+{{define "content"}}
+<article>
+    <h3>File Upload</h3>
+
+    <h4>Tier 1: Standard HTML</h4>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="file" name="document">
+        <button type="submit">Upload</button>
+    </form>
+
+    <h4>Tier 2: Chunked with Progress</h4>
+    <form method="POST">
+        <input type="file" lvt-upload="chunked-doc" name="chunked-doc">
+        <button type="submit">Upload</button>
+    </form>
+
+    {{if .Uploaded}}
+    <ins style="display:block;text-decoration:none">Uploaded: {{.UploadName}}</ins>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/forms/file-upload.tmpl
+++ b/patterns/templates/forms/file-upload.tmpl
@@ -3,19 +3,24 @@
     <h3>File Upload</h3>
 
     <h4>Tier 1: Standard HTML</h4>
-    <form method="POST" enctype="multipart/form-data">
+    <form method="POST" enctype="multipart/form-data" lvt-form:preserve>
         <input type="file" name="document">
-        <button type="submit">Upload</button>
+        <button type="submit" name="upload">Upload</button>
     </form>
 
     <h4>Tier 2: Chunked with Progress</h4>
-    <form method="POST">
+    <form method="POST" lvt-form:preserve>
         <input type="file" lvt-upload="chunked-doc" name="chunked-doc">
-        <button type="submit">Upload</button>
+        {{range .lvt.Uploads "chunked-doc"}}
+        <div>
+            <small><strong>{{.ClientName}}</strong> — {{.Progress}}%</small>
+            <progress value="{{.Progress}}" max="100"></progress>
+        </div>
+        {{end}}
+        <button type="submit" name="upload">Upload</button>
     </form>
 
-    {{if .Uploaded}}
-    <ins style="display:block;text-decoration:none">Uploaded: {{.UploadName}}</ins>
-    {{end}}
+    {{.lvt.FlashTag "success"}}
+    {{.lvt.FlashTag "error"}}
 </article>
 {{end}}

--- a/patterns/templates/forms/inline-validation.tmpl
+++ b/patterns/templates/forms/inline-validation.tmpl
@@ -1,0 +1,21 @@
+{{define "content"}}
+<article>
+    <h3>Inline Validation</h3>
+    <form method="POST">
+        <fieldset>
+            <label>Email
+                <input type="email" name="email" value="{{.Email}}" required
+                    {{if .lvt.HasError "email"}}aria-invalid="true"{{end}}>
+                {{if .lvt.HasError "email"}}<small>{{.lvt.Error "email"}}</small>{{end}}
+            </label>
+            <label>Username
+                <input name="username" value="{{.Username}}" required minlength="3" maxlength="20"
+                    {{if .lvt.HasError "username"}}aria-invalid="true"{{end}}>
+                {{if .lvt.HasError "username"}}<small>{{.lvt.Error "username"}}</small>{{end}}
+            </label>
+            <button type="submit">Submit</button>
+        </fieldset>
+    </form>
+    {{if .Saved}}<ins style="display:block;text-decoration:none">Saved successfully!</ins>{{end}}
+</article>
+{{end}}

--- a/patterns/templates/forms/inline-validation.tmpl
+++ b/patterns/templates/forms/inline-validation.tmpl
@@ -4,14 +4,12 @@
     <form method="POST">
         <fieldset>
             <label>Email
-                <input type="email" name="email" value="{{.Email}}" required
-                    {{if .lvt.HasError "email"}}aria-invalid="true"{{end}}>
-                {{if .lvt.HasError "email"}}<small>{{.lvt.Error "email"}}</small>{{end}}
+                <input type="email" name="email" value="{{.Email}}" required {{.lvt.AriaInvalid "email"}}>
+                {{.lvt.ErrorTag "email"}}
             </label>
             <label>Username
-                <input name="username" value="{{.Username}}" required minlength="3" maxlength="20"
-                    {{if .lvt.HasError "username"}}aria-invalid="true"{{end}}>
-                {{if .lvt.HasError "username"}}<small>{{.lvt.Error "username"}}</small>{{end}}
+                <input name="username" value="{{.Username}}" required minlength="3" maxlength="20" {{.lvt.AriaInvalid "username"}}>
+                {{.lvt.ErrorTag "username"}}
             </label>
             <button type="submit">Submit</button>
         </fieldset>

--- a/patterns/templates/forms/preserve-inputs.tmpl
+++ b/patterns/templates/forms/preserve-inputs.tmpl
@@ -1,0 +1,22 @@
+{{define "content"}}
+<article>
+    <h3>Preserving Form Inputs</h3>
+    <form method="POST" lvt-form:preserve>
+        <fieldset>
+            <label>Name
+                <input name="name" value="{{.Name}}" required>
+            </label>
+            <label>Description
+                <textarea name="description">{{.Description}}</textarea>
+            </label>
+            <label>Attachment
+                <input type="file" name="attachment">
+            </label>
+            <button type="submit">Submit</button>
+        </fieldset>
+    </form>
+    {{if .lvt.HasError "name"}}
+    <small>{{.lvt.Error "name"}}</small>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/forms/preserve-inputs.tmpl
+++ b/patterns/templates/forms/preserve-inputs.tmpl
@@ -15,8 +15,7 @@
             <button type="submit">Submit</button>
         </fieldset>
     </form>
-    {{if .lvt.HasError "name"}}
-    <small>{{.lvt.Error "name"}}</small>
-    {{end}}
+    {{.lvt.FlashTag "success"}}
+    {{.lvt.ErrorTag "name"}}
 </article>
 {{end}}

--- a/patterns/templates/forms/reset-input.tmpl
+++ b/patterns/templates/forms/reset-input.tmpl
@@ -1,0 +1,15 @@
+{{define "content"}}
+<article>
+    <h3>Reset User Input</h3>
+    <p><small>Form clears automatically after successful submission — no extra attributes needed.</small></p>
+    <form method="POST">
+        <fieldset role="group">
+            <input name="message" placeholder="Type a message..." required>
+            <button type="submit">Send</button>
+        </fieldset>
+    </form>
+    {{range .Messages}}
+    <p>{{.}}</p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/index.tmpl
+++ b/patterns/templates/index.tmpl
@@ -1,0 +1,17 @@
+{{define "content"}}
+<hgroup>
+    <h2>LiveTemplate Patterns</h2>
+    <p>31 UI patterns demonstrating progressive complexity</p>
+</hgroup>
+{{range .Categories}}
+<article>
+    <h4>{{.Name}}</h4>
+    {{range .Patterns}}
+    <p>
+        {{if .Implemented}}<a href="{{.Path}}">{{.Name}}</a>{{else}}<small>{{.Name}}</small>{{end}}
+        — <small>{{.Description}}</small>
+    </p>
+    {{end}}
+</article>
+{{end}}
+{{end}}

--- a/patterns/templates/index.tmpl
+++ b/patterns/templates/index.tmpl
@@ -8,7 +8,7 @@
     <h4>{{.Name}}</h4>
     {{range .Patterns}}
     <p>
-        {{if .Implemented}}<a href="{{.Path}}">{{.Name}}</a>{{else}}<small>{{.Name}}</small>{{end}}
+        {{if .Implemented}}<a href="{{.Path}}" lvt-nav:no-intercept>{{.Name}}</a>{{else}}<small>{{.Name}}</small>{{end}}
         — <small>{{.Description}}</small>
     </p>
     {{end}}

--- a/patterns/templates/index.tmpl
+++ b/patterns/templates/index.tmpl
@@ -8,7 +8,7 @@
     <h4>{{.Name}}</h4>
     {{range .Patterns}}
     <p>
-        {{if .Implemented}}<a href="{{.Path}}" lvt-nav:no-intercept>{{.Name}}</a>{{else}}<small>{{.Name}}</small>{{end}}
+        {{if .Implemented}}<a href="{{.Path}}">{{.Name}}</a>{{else}}<small>{{.Name}}</small>{{end}}
         — <small>{{.Description}}</small>
     </p>
     {{end}}

--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -17,7 +17,7 @@
 <body>
     <main class="container">
         <nav>
-            <ul><li><a href="/" lvt-nav:no-intercept><strong>Patterns</strong></a></li></ul>
+            <ul><li><a href="/"><strong>Patterns</strong></a></li></ul>
             {{if .Category}}<ul><li><small>{{.Category}}</small></li></ul>{{end}}
         </nav>
         {{template "content" .}}

--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
+    <title>{{.Title}} — LiveTemplate Patterns</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    {{if .lvt.DevMode}}
+    <link rel="stylesheet" href="/livetemplate.css">
+    <script defer src="/livetemplate-client.js"></script>
+    {{else}}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
+    {{end}}
+</head>
+<body>
+    <main class="container">
+        <nav>
+            <ul><li><a href="/"><strong>Patterns</strong></a></li></ul>
+            {{if .Category}}<ul><li><small>{{.Category}}</small></li></ul>{{end}}
+        </nav>
+        {{template "content" .}}
+    </main>
+</body>
+</html>

--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -17,7 +17,7 @@
 <body>
     <main class="container">
         <nav>
-            <ul><li><a href="/"><strong>Patterns</strong></a></li></ul>
+            <ul><li><a href="/" lvt-nav:no-intercept><strong>Patterns</strong></a></li></ul>
             {{if .Category}}<ul><li><small>{{.Category}}</small></li></ul>{{end}}
         </nav>
         {{template "content" .}}

--- a/test-all.sh
+++ b/test-all.sh
@@ -41,6 +41,7 @@ WORKING_EXAMPLES=(
     "avatar-upload"
     "progressive-enhancement"
     "dialog-patterns"
+    "patterns"
 )
 
 # Disabled examples


### PR DESCRIPTION
## Summary

- Implements the patterns example app scaffold and all 7 Forms & Editing patterns from the [patterns proposal](https://github.com/livetemplate/livetemplate/issues/330)
- Each pattern is a focused, isolated demo with its own handler, controller, template, and E2E tests
- Shared layout template with consolidated dev/prod CSS+JS loading and category nav
- Index page catalogs all 31 patterns (7 implemented, 24 marked as coming soon)

### Patterns implemented
1. **Click To Edit** — toggle view/edit with `{{if}}` conditional rendering
2. **Edit Row** — inline table row editing with `data-key` identity
3. **Inline Validation** — `Change()` with `ValidateForm()` and `.lvt.HasError`/`.lvt.Error`
4. **Bulk Update** — batch checkbox operations with `ctx.GetBool()`
5. **Reset User Input** — form auto-clear after successful submission
6. **File Upload** — Tier 1 multipart + Tier 2 `lvt-upload` chunked upload
7. **Preserving File Inputs** — `lvt-form:preserve` retains values across re-renders

### Architecture
- One controller per pattern (avoids method name conflicts)
- `WithParseFiles("templates/layout.tmpl", "templates/forms/<pattern>.tmpl")` for template composition
- `livetemplate.New("layout", ...)` with layout as main template entry point

## Test plan
- [x] All 8 test functions pass (30 subtests total)
- [x] UI_Standards checks on every pattern (CSP compliance, meta tags, container width)
- [x] Visual_Check subtests (skipped without `LVT_VISUAL_CHECK=true`)
- [x] `go build` and `go vet` clean
- [x] `"patterns"` added to WORKING_EXAMPLES in test-all.sh
- [ ] Manual browser review of all 7 patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)