### PR TITLE
feat: patterns example Session 2 (patterns #8-13) + polish sweep

### DIFF
--- a/patterns/cross_handler_nav_test.go
+++ b/patterns/cross_handler_nav_test.go
@@ -270,6 +270,48 @@ func TestCrossHandlerNavigation(t *testing.T) {
 		}
 	})
 
+	t.Run("Index_To_Delete_Row_No_Stale_Dom", func(t *testing.T) {
+		// Regression for cross-handler nav leaving stale index DOM: index's
+		// 7 category <h4>s must NOT remain after clicking into Delete Row.
+		// The later WaitFor on row count is load-bearing — it ensures the
+		// WebSocket's initial tree update has been applied before we check,
+		// so any treeState merge bug actually shows up.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelectorAll('article').length >= 7`, 3*time.Second),
+			chromedp.Click(`a[href="/patterns/lists/delete-row"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Delete Row", 10*time.Second),
+			e2etest.WaitFor(`document.querySelectorAll('tbody tr[data-key]').length === 5`, 5*time.Second),
+			e2etest.WaitForWebSocketReady(10*time.Second),
+		)
+		if err != nil {
+			var articleCount, rowCount, leakedCategoryHeaders int
+			var wrapperHTML string
+			_ = chromedp.Run(ctx,
+				chromedp.Evaluate(`document.querySelectorAll('[data-lvt-id] article').length`, &articleCount),
+				chromedp.Evaluate(`document.querySelectorAll('tbody tr[data-key]').length`, &rowCount),
+				chromedp.Evaluate(`document.querySelectorAll('[data-lvt-id] h4').length`, &leakedCategoryHeaders),
+				chromedp.OuterHTML(`[data-lvt-id]`, &wrapperHTML, chromedp.ByQuery),
+			)
+			t.Fatalf("Navigation bug: articles=%d rows=%d leakedH4=%d. Wrapper HTML:\n%s\nError: %v",
+				articleCount, rowCount, leakedCategoryHeaders, wrapperHTML, err)
+		}
+		// Assert: exactly 1 article, exactly 5 rows, 0 leaked <h4> headers.
+		var articleCount, leakedCategoryHeaders int
+		_ = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelectorAll('[data-lvt-id] article').length`, &articleCount),
+			chromedp.Evaluate(`document.querySelectorAll('[data-lvt-id] h4').length`, &leakedCategoryHeaders),
+		)
+		if leakedCategoryHeaders > 0 {
+			t.Errorf("Stale <h4> category headers leaked from index: %d present", leakedCategoryHeaders)
+		}
+		if articleCount != 1 {
+			t.Errorf("Expected exactly 1 <article>, got %d", articleCount)
+		}
+	})
+
 	t.Run("WebSocket_Works_After_Navigation", func(t *testing.T) {
 		// Start fresh at index
 		err := chromedp.Run(ctx,

--- a/patterns/data.go
+++ b/patterns/data.go
@@ -1,5 +1,12 @@
 package main
 
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
 // Contact represents a person in the demo data.
 type Contact struct {
 	ID    string
@@ -17,8 +24,17 @@ type UserRow struct {
 
 // Item is a generic named item used across multiple patterns.
 type Item struct {
-	ID   string
-	Name string
+	ID    string
+	Name  string
+	Email string
+}
+
+// FilterItem is a todo-like item with status and date, used by URL-Preserved Filters.
+type FilterItem struct {
+	ID     string
+	Name   string
+	Status string // "active" or "completed"
+	Date   string // YYYY-MM-DD
 }
 
 func sampleContacts() []Contact {
@@ -37,6 +53,162 @@ func sampleUsers() []UserRow {
 		{ID: "3", Name: "Fuqua Tarkenton", Email: "fuqua@tarkenton.org", Active: false},
 		{ID: "4", Name: "Kim Yee", Email: "kim@yee.org", Active: false},
 	}
+}
+
+// listDataset (25 items) is used by Delete Row and Click To Load.
+// 25 at page size 10 gives three pages (10, 10, 5). Infinite Scroll uses
+// a larger dedicated dataset so the auto-scroll cascade is actually visible.
+var listDataset = buildItemDataset(25, "Item")
+
+// infiniteScrollDataset (100 items) gives Infinite Scroll enough rows for
+// the auto-pagination cascade to feel real under manual testing.
+var infiniteScrollDataset = buildItemDataset(100, "Row")
+
+func buildItemDataset(n int, namePrefix string) []Item {
+	items := make([]Item, n)
+	for i := range items {
+		id := i + 1
+		items[i] = Item{
+			ID:    fmt.Sprintf("%d", id),
+			Name:  fmt.Sprintf("%s %d", namePrefix, id),
+			Email: fmt.Sprintf("%s%d@example.com", strings.ToLower(namePrefix), id),
+		}
+	}
+	return items
+}
+
+// getItemPage returns a 1-indexed page of listDataset. Empty slice when
+// out of range. Used by Click To Load and Delete Row's initial state.
+func getItemPage(page, size int) []Item {
+	return pageSlice(listDataset, page, size)
+}
+
+// getInfiniteScrollPage returns a 1-indexed page of infiniteScrollDataset.
+func getInfiniteScrollPage(page, size int) []Item {
+	return pageSlice(infiniteScrollDataset, page, size)
+}
+
+func pageSlice(dataset []Item, page, size int) []Item {
+	if page < 1 || size < 1 {
+		return nil
+	}
+	start := (page - 1) * size
+	if start >= len(dataset) {
+		return nil
+	}
+	end := start + size
+	if end > len(dataset) {
+		end = len(dataset)
+	}
+	return slices.Clone(dataset[start:end])
+}
+
+// carMakes maps car makes to their model lists. Used by Value Select to
+// demonstrate cascading dependent selects.
+var carMakes = map[string][]string{
+	"Audi":   {"A3", "A4", "Q5", "R8"},
+	"BMW":    {"3 Series", "5 Series", "X3", "M3"},
+	"Toyota": {"Camry", "Corolla", "RAV4", "Highlander"},
+}
+
+// getCarMakes returns the sorted list of available car makes.
+func getCarMakes() []string {
+	return slices.Sorted(maps.Keys(carMakes))
+}
+
+// getCarModels returns a copy of the models for a given make, or nil if
+// the make is unknown. Returning a copy defends callers from aliasing the
+// package-level carMakes map.
+func getCarModels(carMake string) []string {
+	return slices.Clone(carMakes[carMake])
+}
+
+// contactDirectory is the 25-contact dataset used by Active Search. Kept
+// distinct from sampleContacts() (4 entries) which is pinned by Edit Row tests.
+var contactDirectory = []Contact{
+	{ID: "1", Name: "Marcus Chen", Email: "marcus.chen@example.com"},
+	{ID: "2", Name: "Priya Patel", Email: "priya.patel@example.com"},
+	{ID: "3", Name: "Diana Okonkwo", Email: "diana.okonkwo@example.com"},
+	{ID: "4", Name: "Rafael Hernandez", Email: "rafael.hernandez@example.com"},
+	{ID: "5", Name: "Yuki Tanaka", Email: "yuki.tanaka@example.com"},
+	{ID: "6", Name: "Fatima Al-Rashid", Email: "fatima.alrashid@example.com"},
+	{ID: "7", Name: "Liam O'Brien", Email: "liam.obrien@example.com"},
+	{ID: "8", Name: "Sofia Rossi", Email: "sofia.rossi@example.com"},
+	{ID: "9", Name: "Kwame Asante", Email: "kwame.asante@example.com"},
+	{ID: "10", Name: "Ingrid Nilsson", Email: "ingrid.nilsson@example.com"},
+	{ID: "11", Name: "Arjun Sharma", Email: "arjun.sharma@example.com"},
+	{ID: "12", Name: "Elena Volkov", Email: "elena.volkov@example.com"},
+	{ID: "13", Name: "Mateo Silva", Email: "mateo.silva@example.com"},
+	{ID: "14", Name: "Aisha Bello", Email: "aisha.bello@example.com"},
+	{ID: "15", Name: "Thomas Weber", Email: "thomas.weber@example.com"},
+	{ID: "16", Name: "Nadia Haddad", Email: "nadia.haddad@example.com"},
+	{ID: "17", Name: "Jin-ho Park", Email: "jinho.park@example.com"},
+	{ID: "18", Name: "Olivia Bennett", Email: "olivia.bennett@example.com"},
+	{ID: "19", Name: "Samuel Adeyemi", Email: "samuel.adeyemi@example.com"},
+	{ID: "20", Name: "Carmen Reyes", Email: "carmen.reyes@example.com"},
+	{ID: "21", Name: "Henrik Larsen", Email: "henrik.larsen@example.com"},
+	{ID: "22", Name: "Meera Krishnan", Email: "meera.krishnan@example.com"},
+	{ID: "23", Name: "Luca Bianchi", Email: "luca.bianchi@example.com"},
+	{ID: "24", Name: "Zara Ahmed", Email: "zara.ahmed@example.com"},
+	{ID: "25", Name: "Gabriel Martinez", Email: "gabriel.martinez@example.com"},
+}
+
+// searchContacts returns contacts whose name or email contains query
+// (case-insensitive). Empty query returns the full directory.
+func searchContacts(query string) []Contact {
+	if query == "" {
+		return slices.Clone(contactDirectory)
+	}
+	q := strings.ToLower(query)
+	out := make([]Contact, 0, len(contactDirectory))
+	for _, c := range contactDirectory {
+		if strings.Contains(strings.ToLower(c.Name), q) || strings.Contains(strings.ToLower(c.Email), q) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// filterDataset is the set of items used by URL-Preserved Filters.
+// Mix of active/completed statuses and dates spanning ~1 year.
+var filterDataset = []FilterItem{
+	{ID: "1", Name: "Design homepage", Status: "completed", Date: "2024-02-14"},
+	{ID: "2", Name: "Draft Q1 proposal", Status: "completed", Date: "2024-03-01"},
+	{ID: "3", Name: "Review authentication spec", Status: "active", Date: "2024-03-15"},
+	{ID: "4", Name: "Migrate legacy database", Status: "active", Date: "2024-04-02"},
+	{ID: "5", Name: "Write onboarding docs", Status: "completed", Date: "2024-04-20"},
+	{ID: "6", Name: "Upgrade CI pipeline", Status: "active", Date: "2024-05-08"},
+	{ID: "7", Name: "Host team offsite", Status: "completed", Date: "2024-06-12"},
+	{ID: "8", Name: "Ship payments beta", Status: "active", Date: "2024-07-04"},
+	{ID: "9", Name: "Audit access controls", Status: "completed", Date: "2024-08-19"},
+	{ID: "10", Name: "Refactor billing module", Status: "active", Date: "2024-09-28"},
+	{ID: "11", Name: "Launch mobile app", Status: "active", Date: "2024-11-11"},
+	{ID: "12", Name: "Year-end retrospective", Status: "active", Date: "2024-12-30"},
+}
+
+// filterItems returns filterDataset filtered by status and sorted by sort key.
+// Unknown status values are treated as "all"; unknown sort values fall back to "name".
+func filterItems(status, sort string) []FilterItem {
+	out := make([]FilterItem, 0, len(filterDataset))
+	for _, item := range filterDataset {
+		if status == "active" || status == "completed" {
+			if item.Status != status {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	switch sort {
+	case "date":
+		slices.SortFunc(out, func(a, b FilterItem) int {
+			return strings.Compare(b.Date, a.Date) // descending (newest first)
+		})
+	default: // "name" and any unknown value
+		slices.SortFunc(out, func(a, b FilterItem) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+	}
+	return out
 }
 
 // PatternLink describes a single pattern in the index page catalog.
@@ -70,17 +242,17 @@ func allPatterns() []PatternCategory {
 		{
 			Name: "Lists & Data",
 			Patterns: []PatternLink{
-				{Name: "Delete Row", Path: "/patterns/lists/delete-row", Description: "Animated row removal"},
-				{Name: "Click To Load", Path: "/patterns/lists/click-to-load", Description: "Append-only pagination"},
-				{Name: "Infinite Scroll", Path: "/patterns/lists/infinite-scroll", Description: "Auto-load on scroll with IntersectionObserver"},
-				{Name: "Value Select", Path: "/patterns/lists/value-select", Description: "Cascading dependent selects"},
+				{Name: "Delete Row", Path: "/patterns/lists/delete-row", Description: "Animated row removal", Implemented: true},
+				{Name: "Click To Load", Path: "/patterns/lists/click-to-load", Description: "Append-only pagination", Implemented: true},
+				{Name: "Infinite Scroll", Path: "/patterns/lists/infinite-scroll", Description: "Auto-load on scroll with IntersectionObserver", Implemented: true},
+				{Name: "Value Select", Path: "/patterns/lists/value-select", Description: "Cascading dependent selects", Implemented: true},
 			},
 		},
 		{
 			Name: "Search & Filtering",
 			Patterns: []PatternLink{
-				{Name: "Active Search", Path: "/patterns/search/active-search", Description: "Debounced live search"},
-				{Name: "URL-Preserved Filters", Path: "/patterns/search/url-filters", Description: "Bookmarkable filter state via query params"},
+				{Name: "Active Search", Path: "/patterns/search/active-search", Description: "Debounced live search", Implemented: true},
+				{Name: "URL-Preserved Filters", Path: "/patterns/search/url-filters", Description: "Bookmarkable filter state via query params", Implemented: true},
 			},
 		},
 		{

--- a/patterns/handlers_forms.go
+++ b/patterns/handlers_forms.go
@@ -49,12 +49,14 @@ func clickToEditHandler(baseOpts []livetemplate.Option) http.Handler {
 type EditRowController struct{}
 
 func (c *EditRowController) Edit(state EditRowState, ctx *livetemplate.Context) (EditRowState, error) {
-	state.EditingID = ctx.GetString("id")
+	// Edit/Save buttons send their ID via `value` attribute — see
+	// docs/references/progressive-complexity-reference.md.
+	state.EditingID = ctx.GetString("value")
 	return state, nil
 }
 
 func (c *EditRowController) Save(state EditRowState, ctx *livetemplate.Context) (EditRowState, error) {
-	id := ctx.GetString("id")
+	id := ctx.GetString("value")
 	for i, contact := range state.Contacts {
 		if contact.ID == id {
 			state.Contacts[i].Name = ctx.GetString("name")
@@ -122,10 +124,19 @@ func inlineValidationHandler(baseOpts []livetemplate.Option) http.Handler {
 type BulkUpdateController struct{}
 
 func (c *BulkUpdateController) BulkUpdate(state BulkUpdateState, ctx *livetemplate.Context) (BulkUpdateState, error) {
+	changed := 0
 	for i, user := range state.Users {
-		state.Users[i].Active = ctx.GetBool("active-" + user.ID)
+		newActive := ctx.GetBool("active-" + user.ID)
+		if newActive != user.Active {
+			changed++
+		}
+		state.Users[i].Active = newActive
 	}
-	ctx.SetFlash("success", fmt.Sprintf("Updated %d user(s)", len(state.Users)))
+	if changed == 0 {
+		ctx.SetFlash("info", "No changes")
+	} else {
+		ctx.SetFlash("success", fmt.Sprintf("Updated %d user(s)", changed))
+	}
 	return state, nil
 }
 

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"net/http"
+	"slices"
+	"sync"
+
+	"github.com/livetemplate/livetemplate"
+)
+
+// listPageSize is the page size used by Click To Load (#9) and Infinite Scroll (#10).
+const listPageSize = 10
+
+// --- Pattern #8: Delete Row ---
+
+// DeleteRowController holds a shared in-memory "database" protected by a
+// mutex. Mount copies the DB snapshot into per-session state on every
+// connect, so deletions persist across reloads and cross-handler navigation
+// without needing `lvt:"persist"` struct tags. The DB lives for the life
+// of the process; restarting the server resets it.
+type DeleteRowController struct {
+	mu    sync.Mutex
+	items []Item
+}
+
+const deleteRowInitialCount = 5
+
+func newDeleteRowController() *DeleteRowController {
+	return &DeleteRowController{items: getItemPage(1, deleteRowInitialCount)}
+}
+
+// snapshot returns an independent copy of the current DB. Caller must not
+// hold c.mu when invoking (this method acquires it internally).
+func (c *DeleteRowController) snapshot() []Item {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.items)
+}
+
+func (c *DeleteRowController) Mount(state DeleteRowState, ctx *livetemplate.Context) (DeleteRowState, error) {
+	state.Items = c.snapshot()
+	return state, nil
+}
+
+func (c *DeleteRowController) Delete(state DeleteRowState, ctx *livetemplate.Context) (DeleteRowState, error) {
+	// Button sends its `value` attribute as data.value — see
+	// docs/references/progressive-complexity-reference.md.
+	id := ctx.GetString("value")
+	c.mu.Lock()
+	c.items = slices.DeleteFunc(c.items, func(item Item) bool {
+		return item.ID == id
+	})
+	c.mu.Unlock()
+	state.Items = c.snapshot()
+	return state, nil
+}
+
+// Restore refills the DB to its initial state. Wired to a button that
+// appears after the last item is deleted, so visitors can reset the demo
+// without restarting the server.
+func (c *DeleteRowController) Restore(state DeleteRowState, ctx *livetemplate.Context) (DeleteRowState, error) {
+	c.mu.Lock()
+	c.items = getItemPage(1, deleteRowInitialCount)
+	c.mu.Unlock()
+	state.Items = c.snapshot()
+	return state, nil
+}
+
+func deleteRowHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/lists/delete-row.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(newDeleteRowController(), livetemplate.AsState(&DeleteRowState{
+		Title:    "Delete Row",
+		Category: "Lists & Data",
+	}))
+}
+
+// --- Pattern #9: Click To Load ---
+
+type ClickToLoadController struct{}
+
+func (c *ClickToLoadController) LoadMore(state ClickToLoadState, ctx *livetemplate.Context) (ClickToLoadState, error) {
+	state.CurrentPage++
+	newItems := getItemPage(state.CurrentPage, listPageSize)
+	state.Items = append(state.Items, newItems...)
+	state.HasMore = len(newItems) == listPageSize
+	return state, nil
+}
+
+func clickToLoadHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/lists/click-to-load.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ClickToLoadController{}, livetemplate.AsState(&ClickToLoadState{
+		Title:       "Click To Load",
+		Category:    "Lists & Data",
+		Items:       getItemPage(1, listPageSize),
+		CurrentPage: 1,
+		HasMore:     true,
+	}))
+}
+
+// --- Pattern #11: Value Select (Cascading Selects) ---
+
+type ValueSelectController struct{}
+
+func (c *ValueSelectController) Mount(state ValueSelectState, ctx *livetemplate.Context) (ValueSelectState, error) {
+	state.Makes = getCarMakes()
+	if state.Make != "" {
+		state.Models = getCarModels(state.Make)
+	}
+	return state, nil
+}
+
+func (c *ValueSelectController) Change(state ValueSelectState, ctx *livetemplate.Context) (ValueSelectState, error) {
+	if ctx.Has("make") {
+		state.Make = ctx.GetString("make")
+		state.Models = getCarModels(state.Make)
+		// Auto-select first model so the user sees the cascade propagate.
+		state.Model = ""
+		if len(state.Models) > 0 {
+			state.Model = state.Models[0]
+		}
+	}
+	if ctx.Has("model") {
+		state.Model = ctx.GetString("model")
+	}
+	return state, nil
+}
+
+func valueSelectHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/lists/value-select.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ValueSelectController{}, livetemplate.AsState(&ValueSelectState{
+		Title:    "Value Select",
+		Category: "Lists & Data",
+	}))
+}
+
+// --- Pattern #10: Infinite Scroll ---
+
+type InfiniteScrollController struct{}
+
+// LoadMore is dispatched by the client-side IntersectionObserver when
+// <div id="scroll-sentinel"> becomes visible. Uses the larger
+// infiniteScrollDataset (100 items) so the auto-pagination cascade is
+// actually visible during the demo; ClickToLoad uses the 25-item
+// listDataset which only needs a couple of clicks.
+func (c *InfiniteScrollController) LoadMore(state InfiniteScrollState, ctx *livetemplate.Context) (InfiniteScrollState, error) {
+	state.CurrentPage++
+	newItems := getInfiniteScrollPage(state.CurrentPage, listPageSize)
+	state.Items = append(state.Items, newItems...)
+	state.HasMore = len(newItems) == listPageSize
+	return state, nil
+}
+
+func infiniteScrollHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/lists/infinite-scroll.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&InfiniteScrollController{}, livetemplate.AsState(&InfiniteScrollState{
+		Title:       "Infinite Scroll",
+		Category:    "Lists & Data",
+		Items:       getInfiniteScrollPage(1, listPageSize),
+		CurrentPage: 1,
+		HasMore:     true,
+	}))
+}

--- a/patterns/handlers_search.go
+++ b/patterns/handlers_search.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/livetemplate/livetemplate"
+)
+
+// --- Pattern #12: Active Search ---
+
+type ActiveSearchController struct{}
+
+func (c *ActiveSearchController) Mount(state ActiveSearchState, ctx *livetemplate.Context) (ActiveSearchState, error) {
+	// Full directory visible on initial render so the "filter down" story is obvious.
+	state.Results = searchContacts(state.Query)
+	return state, nil
+}
+
+func (c *ActiveSearchController) Change(state ActiveSearchState, ctx *livetemplate.Context) (ActiveSearchState, error) {
+	if ctx.Has("query") {
+		state.Query = ctx.GetString("query")
+		state.Results = searchContacts(state.Query)
+	}
+	return state, nil
+}
+
+func activeSearchHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/search/active-search.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ActiveSearchController{}, livetemplate.AsState(&ActiveSearchState{
+		Title:    "Active Search",
+		Category: "Search & Filtering",
+	}))
+}
+
+// --- Pattern #13: URL-Preserved Filters ---
+
+type URLFiltersController struct{}
+
+// validStatuses / validSorts allow Mount to reject unknown query param values
+// without crashing: unknown values fall back to the previous/default state
+// rather than producing a 404 or an error. Bookmarks with stale params still
+// render usefully.
+var (
+	validStatuses = map[string]bool{"all": true, "active": true, "completed": true}
+	validSorts    = map[string]bool{"name": true, "date": true}
+)
+
+func (c *URLFiltersController) Mount(state URLFiltersState, ctx *livetemplate.Context) (URLFiltersState, error) {
+	// ctx.Action() == "" means this is a GET navigation (initial load or SPA
+	// link click), not a POST action. Only read URL query params on GET to
+	// avoid clobbering state from an in-flight action.
+	if ctx.Action() == "" {
+		if s := ctx.GetString("status"); s != "" && validStatuses[s] {
+			state.Status = s
+		}
+		if s := ctx.GetString("sort"); s != "" && validSorts[s] {
+			state.Sort = s
+		}
+	}
+	// Always recompute the item list so the initial render (with defaults)
+	// and any subsequent action both see fresh data.
+	state.Items = filterItems(state.Status, state.Sort)
+	return state, nil
+}
+
+func urlFiltersHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/search/url-filters.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&URLFiltersController{}, livetemplate.AsState(&URLFiltersState{
+		Title:    "URL-Preserved Filters",
+		Category: "Search & Filtering",
+		Status:   "all",
+		Sort:     "name",
+	}))
+}

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -75,6 +75,16 @@ func main() {
 	mux.Handle("/patterns/forms/file-upload", fileUploadHandler(baseOpts))
 	mux.Handle("/patterns/forms/preserve-inputs", preserveInputsHandler(baseOpts))
 
+	// Category: Lists & Data (#8–#11)
+	mux.Handle("/patterns/lists/delete-row", deleteRowHandler(baseOpts))
+	mux.Handle("/patterns/lists/click-to-load", clickToLoadHandler(baseOpts))
+	mux.Handle("/patterns/lists/infinite-scroll", infiniteScrollHandler(baseOpts))
+	mux.Handle("/patterns/lists/value-select", valueSelectHandler(baseOpts))
+
+	// Category: Search & Filtering (#12–#13)
+	mux.Handle("/patterns/search/active-search", activeSearchHandler(baseOpts))
+	mux.Handle("/patterns/search/url-filters", urlFiltersHandler(baseOpts))
+
 	// Client library and CSS (dev mode)
 	if localClient := os.Getenv("LVT_LOCAL_CLIENT"); localClient != "" {
 		mux.HandleFunc("/livetemplate-client.js", func(w http.ResponseWriter, r *http.Request) {

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1186,16 +1186,26 @@ func TestActiveSearch(t *testing.T) {
 	})
 
 	t.Run("Clear_Query_Restores_All", func(t *testing.T) {
-		// chromedp.Clear doesn't fire DOM events — set value and dispatch input
-		// together in a single script so the Change auto-wirer picks it up.
+		// chromedp.Clear doesn't fire DOM events — set value and dispatch both
+		// `input` (what the Change auto-wirer listens for on text inputs) and
+		// `change` (defensive for event-filter implementations) in a single
+		// script so the auto-wirer picks it up regardless.
+		//
+		// Timeout bumped to 10s: this test was flaky under CI load where
+		// orphan processes from earlier tests compete for CPU. Locally
+		// completes in ~0.4s; CI failure pattern was a hard 5s timeout
+		// while still showing the previous query's 1-result state.
 		err := chromedp.Run(ctx,
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.Focus(`input[name="query"]`, chromedp.ByQuery),
 			chromedp.Evaluate(`(() => {
 				const el = document.querySelector('input[name="query"]');
 				el.value = '';
 				el.dispatchEvent(new Event('input', { bubbles: true }));
+				el.dispatchEvent(new Event('change', { bubbles: true }));
 				return el.value;
 			})()`, nil),
-			e2etest.WaitForCount(`tbody tr[data-key]`, 25, 5*time.Second),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 25, 10*time.Second),
 		)
 		if err != nil {
 			t.Fatalf("Failed to clear query: %v", err)

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -103,6 +103,24 @@ func runUIStandardsWithPico(t *testing.T, ctx context.Context) {
 	}
 }
 
+// runStandardSubtests runs the boilerplate `UI_Standards` + `Visual_Check`
+// subtest pair. `pico=true` invokes the Pico-variant UI check. Patterns
+// that need additional setup before the UI check (e.g. waiting for
+// entry animations to finish) should inline the subtests instead.
+func runStandardSubtests(t *testing.T, ctx context.Context, pico bool, screenshotDesc string) {
+	t.Helper()
+	t.Run("UI_Standards", func(t *testing.T) {
+		if pico {
+			runUIStandardsWithPico(t, ctx)
+		} else {
+			runUIStandards(t, ctx)
+		}
+	})
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, screenshotDesc)
+	})
+}
+
 // attachFileViaDataTransfer sets a File on the given file input using the
 // DataTransfer API. chromedp.SetUploadFiles cannot be used with Docker
 // Chrome because the container has no access to host filesystem paths.
@@ -149,13 +167,7 @@ func TestIndexPage(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Pattern index page — heading, 7 category cards with pattern links and descriptions")
-	})
+	runStandardSubtests(t, ctx, true, "Pattern index page — heading, 7 category cards with pattern links and descriptions")
 
 	t.Run("Pattern_Links", func(t *testing.T) {
 		var count int
@@ -207,13 +219,7 @@ func TestClickToEdit(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Click To Edit — view mode with name/email displayed and Edit button")
-	})
+	runStandardSubtests(t, ctx, true, "Click To Edit — view mode with name/email displayed and Edit button")
 
 	t.Run("Edit_Mode", func(t *testing.T) {
 		var html string
@@ -318,13 +324,7 @@ func TestEditRow(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Edit Row — table with 4 contacts, each with name/email and Edit button")
-	})
+	runStandardSubtests(t, ctx, true, "Edit Row — table with 4 contacts, each with name/email and Edit button")
 
 	t.Run("Edit_Row", func(t *testing.T) {
 		// Click Edit on the first row
@@ -426,13 +426,7 @@ func TestInlineValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandards(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Inline Validation — email and username inputs with submit button, no errors shown yet")
-	})
+	runStandardSubtests(t, ctx, false, "Inline Validation — email and username inputs with submit button, no errors shown yet")
 
 	t.Run("Valid_Submit", func(t *testing.T) {
 		var html string
@@ -496,13 +490,7 @@ func TestBulkUpdate(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Bulk Update — table with 4 users, checkboxes for active status, Update button")
-	})
+	runStandardSubtests(t, ctx, true, "Bulk Update — table with 4 users, checkboxes for active status, Update button")
 
 	t.Run("Toggle_And_Update", func(t *testing.T) {
 		err := chromedp.Run(ctx,
@@ -542,6 +530,18 @@ func TestBulkUpdate(t *testing.T) {
 			t.Error("User 4 should still be inactive")
 		}
 	})
+
+	t.Run("Submit_With_No_Changes", func(t *testing.T) {
+		// Clicking Update without toggling anything should report
+		// "No changes" instead of a spurious "Updated N user(s)" count.
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="bulkUpdate"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash]`, "No changes", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Expected 'No changes' flash, got: %v", err)
+		}
+	})
 }
 
 // --- Pattern #5: Reset User Input ---
@@ -573,13 +573,7 @@ func TestResetInput(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Reset User Input — message input with Send button, info text about auto-clear")
-	})
+	runStandardSubtests(t, ctx, true, "Reset User Input — message input with Send button, info text about auto-clear")
 
 	t.Run("Submit_Message", func(t *testing.T) {
 		var html string
@@ -667,13 +661,7 @@ func TestFileUpload(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandardsWithPico(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "File Upload — two sections: Tier 1 standard HTML upload and Tier 2 chunked upload, each with file input and Upload button")
-	})
+	runStandardSubtests(t, ctx, true, "File Upload — two sections: Tier 1 standard HTML upload and Tier 2 chunked upload, each with file input and Upload button")
 
 	t.Run("Submit_Without_File", func(t *testing.T) {
 		err := chromedp.Run(ctx,
@@ -761,13 +749,7 @@ func TestPreserveInputs(t *testing.T) {
 		}
 	})
 
-	t.Run("UI_Standards", func(t *testing.T) {
-		runUIStandards(t, ctx)
-	})
-
-	t.Run("Visual_Check", func(t *testing.T) {
-		e2etest.ValidateScreenshotWithLLM(t, ctx, "Preserving Form Inputs — name input, description textarea, file attachment input, submit button")
-	})
+	runStandardSubtests(t, ctx, false, "Preserving Form Inputs — name input, description textarea, file attachment input, submit button")
 
 	t.Run("Submit_Shows_Flash", func(t *testing.T) {
 		err := chromedp.Run(ctx,
@@ -839,6 +821,629 @@ func TestPreserveInputs(t *testing.T) {
 		)
 		if err != nil {
 			t.Fatalf("Submit with file attached failed: %v", err)
+		}
+	})
+}
+
+// --- Pattern #8: Delete Row ---
+
+func TestDeleteRow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/delete-row"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 5, 5*time.Second),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		for i := 1; i <= 5; i++ {
+			if !strings.Contains(html, fmt.Sprintf(`data-key="%d"`, i)) {
+				t.Errorf("Row with data-key=%q not found", fmt.Sprintf("%d", i))
+			}
+		}
+	})
+
+	t.Run("UI_Standards", func(t *testing.T) {
+		// Wait for lvt-fx:animate entry animations to finish before the
+		// inline-style check — animationend clears the style attribute.
+		err := chromedp.Run(ctx,
+			e2etest.WaitFor(`Array.from(document.querySelectorAll('[data-key]')).every(el => !el.hasAttribute('style'))`, 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Animations did not complete: %v", err)
+		}
+		runUIStandards(t, ctx)
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Delete Row — table with 5 items showing ID, Name, Email columns and a Delete button on each row")
+	})
+
+	t.Run("Delete_First_Row", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Click(`tr[data-key="1"] button[name="delete"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 4, 5*time.Second),
+			chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to delete first row: %v", err)
+		}
+		if strings.Contains(html, `data-key="1"`) {
+			t.Error("Row 1 still present after delete")
+		}
+		if !strings.Contains(html, `data-key="2"`) {
+			t.Error("Row 2 should still be present")
+		}
+	})
+
+	t.Run("Delete_All_Remaining_Rows", func(t *testing.T) {
+		// Delete rows 2, 3, 4, 5 one at a time, asserting the count after each.
+		for _, row := range []struct {
+			id            string
+			expectedAfter int
+		}{
+			{"2", 3},
+			{"3", 2},
+			{"4", 1},
+			{"5", 0},
+		} {
+			err := chromedp.Run(ctx,
+				chromedp.Click(fmt.Sprintf(`tr[data-key="%s"] button[name="delete"]`, row.id), chromedp.ByQuery),
+				e2etest.WaitForCount(`tbody tr[data-key]`, row.expectedAfter, 5*time.Second),
+			)
+			if err != nil {
+				t.Fatalf("Failed to delete row %s: %v", row.id, err)
+			}
+		}
+		// Assert empty state message appears and Restore button is present
+		err := chromedp.Run(ctx,
+			e2etest.WaitForText(`article`, "All items deleted", 5*time.Second),
+			chromedp.WaitVisible(`button[name="restore"]`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Empty state or restore button not shown: %v", err)
+		}
+	})
+
+	t.Run("State_Persists_Across_Reload", func(t *testing.T) {
+		// Reload the page — the shared in-memory DB should still be empty
+		// from the previous Delete_All_Remaining_Rows subtest, proving that
+		// state persists across reloads without needing lvt:"persist" tags.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			e2etest.WaitForText(`article`, "All items deleted", 5*time.Second),
+			chromedp.WaitVisible(`button[name="restore"]`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Empty state did not persist across reload: %v", err)
+		}
+	})
+
+	t.Run("Restore_Refills_Items", func(t *testing.T) {
+		// Click Restore to refill the DB. All 5 items should reappear.
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="restore"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 5, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Restore did not refill items: %v", err)
+		}
+	})
+}
+
+// --- Pattern #9: Click To Load ---
+
+func TestClickToLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/click-to-load"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var html string
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 10, 5*time.Second),
+			chromedp.OuterHTML(`article`, &html, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		if !strings.Contains(html, `name="loadMore"`) {
+			t.Error("Load More button not found")
+		}
+		if !strings.Contains(html, "Item 10") {
+			t.Error("First page's last item (Item 10) not found")
+		}
+		if strings.Contains(html, "Item 11") {
+			t.Error("Second page item (Item 11) should not be present yet")
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Click To Load — table with 10 rows (ID, Name, Email) and a Load More button below")
+
+	t.Run("Load_Second_Page", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="loadMore"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 20, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load second page: %v", err)
+		}
+		var html string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read tbody: %v", err)
+		}
+		if !strings.Contains(html, "Item 11") {
+			t.Error("Second page item (Item 11) not found after load")
+		}
+		if !strings.Contains(html, "Item 20") {
+			t.Error("Second page's last item (Item 20) not found after load")
+		}
+	})
+
+	t.Run("Load_Third_Page_And_Hide_Button", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="loadMore"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 25, 5*time.Second),
+			// Wait for the button to disappear (HasMore flips false when the
+			// final page returns fewer than listPageSize items).
+			e2etest.WaitFor(`document.querySelector('button[name="loadMore"]') === null`, 5*time.Second),
+			e2etest.WaitForText(`article`, "End of list", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load third page: %v", err)
+		}
+	})
+}
+
+// --- Pattern #11: Value Select ---
+
+// selectValueAndDispatchChange sets a <select>'s value and dispatches a
+// bubbling change event so the LiveTemplate client's Change auto-wirer fires.
+// chromedp.Click cannot open native <select> dropdowns in headless Chrome.
+func selectValueAndDispatchChange(selector, value string) chromedp.Action {
+	script := fmt.Sprintf(`(() => {
+		const el = document.querySelector(%q);
+		if (!el) return 'missing:' + %q;
+		el.value = %q;
+		el.dispatchEvent(new Event('change', { bubbles: true }));
+		return 'ok';
+	})()`, selector, selector, value)
+	return chromedp.Evaluate(script, nil)
+}
+
+func TestValueSelect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/value-select"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		var makeOptionCount int
+		var modelDisabled bool
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`select[name="make"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			chromedp.Evaluate(`document.querySelectorAll('select[name="make"] option').length`, &makeOptionCount),
+			chromedp.Evaluate(`document.querySelector('select[name="model"]').disabled`, &modelDisabled),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		// 1 placeholder + 3 makes (Audi, BMW, Toyota)
+		if makeOptionCount != 4 {
+			t.Errorf("Expected 4 make options, got %d", makeOptionCount)
+		}
+		if !modelDisabled {
+			t.Error("Model select should be disabled when no make is selected")
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Value Select — Make dropdown with 3 car makes and Model dropdown disabled until a make is selected")
+
+	t.Run("Select_Make_Auto_Selects_First_Model", func(t *testing.T) {
+		// Selecting a Make auto-selects the first Model for immediate visual
+		// feedback — the Model dropdown's value updates and the "Selected:"
+		// line appears without needing a second user click.
+		err := chromedp.Run(ctx,
+			selectValueAndDispatchChange(`select[name="make"]`, "Audi"),
+			// Wait for Model options to be populated (4 models + placeholder = 5).
+			e2etest.WaitFor(`document.querySelectorAll('select[name="model"] option').length === 5`, 5*time.Second),
+			// Wait for the auto-selected "Audi A3" line to appear.
+			e2etest.WaitForText(`article`, "Audi A3", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to select make or auto-select model: %v", err)
+		}
+		var html string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`select[name="model"]`, &html, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read model select: %v", err)
+		}
+		for _, model := range []string{"A3", "A4", "Q5", "R8"} {
+			if !strings.Contains(html, model) {
+				t.Errorf("Expected Audi model %q in select, got:\n%s", model, html)
+			}
+		}
+	})
+
+	t.Run("Select_Model_Updates_Selection", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			selectValueAndDispatchChange(`select[name="model"]`, "A4"),
+			e2etest.WaitForText(`article`, "Audi A4", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to select model: %v", err)
+		}
+	})
+
+	t.Run("Change_Make_Auto_Selects_New_First_Model", func(t *testing.T) {
+		// Switching Make auto-selects the new Make's first Model — so the
+		// previous "Audi A4" line becomes "BMW 3 Series" without the user
+		// needing to touch the Model dropdown.
+		err := chromedp.Run(ctx,
+			selectValueAndDispatchChange(`select[name="make"]`, "BMW"),
+			e2etest.WaitFor(`(() => {
+				const opts = document.querySelectorAll('select[name="model"] option');
+				if (opts.length !== 5) return false;
+				const texts = Array.from(opts).map(o => o.textContent);
+				return texts.includes('3 Series') && !texts.includes('A4');
+			})()`, 5*time.Second),
+			e2etest.WaitForText(`article`, "BMW 3 Series", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to switch make or auto-select new model: %v", err)
+		}
+		// The previous "Audi A4" line should be gone.
+		var html string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`article`, &html, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read article: %v", err)
+		}
+		if strings.Contains(html, "Audi A4") {
+			t.Error("Previous selection 'Audi A4' should be cleared after make change")
+		}
+	})
+}
+
+// --- Pattern #12: Active Search ---
+
+func TestActiveSearch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/search/active-search"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`input[name="query"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			// Full directory is 25 contacts
+			e2etest.WaitForCount(`tbody tr[data-key]`, 25, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Active Search — search input labeled 'Search contacts' with a table of 25 contacts showing Name and Email columns below")
+
+	t.Run("Filter_To_Single_Result", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Focus(`input[name="query"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="query"]`, "Chen", chromedp.ByQuery),
+			// WaitForCount naturally waits out the 300ms debounce
+			e2etest.WaitForCount(`tbody tr[data-key]`, 1, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to filter results: %v", err)
+		}
+		var html string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read tbody: %v", err)
+		}
+		if !strings.Contains(html, "Marcus Chen") {
+			t.Errorf("Expected Marcus Chen in results, got:\n%s", html)
+		}
+	})
+
+	t.Run("Clear_Query_Restores_All", func(t *testing.T) {
+		// chromedp.Clear doesn't fire DOM events — set value and dispatch input
+		// together in a single script so the Change auto-wirer picks it up.
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`(() => {
+				const el = document.querySelector('input[name="query"]');
+				el.value = '';
+				el.dispatchEvent(new Event('input', { bubbles: true }));
+				return el.value;
+			})()`, nil),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 25, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to clear query: %v", err)
+		}
+	})
+
+	t.Run("Empty_Results_Shows_No_Results", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Focus(`input[name="query"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`input[name="query"]`, "xzyzzzz-no-match", chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 0, 5*time.Second),
+			e2etest.WaitForText(`article`, "No contacts match", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to show empty results: %v", err)
+		}
+	})
+}
+
+// --- Pattern #13: URL-Preserved Filters ---
+
+func TestURLFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	baseURL := e2etest.GetChromeTestURL(serverPort) + "/patterns/search/url-filters"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			// Full dataset: 12 items
+			e2etest.WaitForCount(`tbody tr[data-key]`, 12, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load page: %v", err)
+		}
+		// "All" and "By Name" should have aria-current="page"
+		var html string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`article nav`, &html, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read nav: %v", err)
+		}
+		if !strings.Contains(html, `aria-current="page">All`) {
+			t.Errorf("Expected 'All' link marked aria-current, got:\n%s", html)
+		}
+		if !strings.Contains(html, `aria-current="page">By Name`) {
+			t.Errorf("Expected 'By Name' link marked aria-current, got:\n%s", html)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "URL-Preserved Filters — two groups of filter links (status: All/Active/Completed and sort: By Name/By Date) above a table of items with Name, Status, Date columns")
+
+	t.Run("Filter_By_Active", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`a[href="?status=active&sort=name"]`, chromedp.ByQuery),
+			// 7 active items in filterDataset (IDs 3, 4, 6, 8, 10, 11, 12).
+			e2etest.WaitForCount(`tbody tr[data-key]`, 7, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to filter by active: %v", err)
+		}
+		var currentURL string
+		err = chromedp.Run(ctx, chromedp.Location(&currentURL))
+		if err != nil {
+			t.Fatalf("Failed to read URL: %v", err)
+		}
+		if !strings.Contains(currentURL, "status=active") {
+			t.Errorf("URL should contain status=active, got: %s", currentURL)
+		}
+	})
+
+	t.Run("Bookmarkable_Reload", func(t *testing.T) {
+		// Direct navigate to a filtered URL (simulates bookmark reload).
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL+"?status=completed&sort=date"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			// Completed items: 1, 2, 5, 7, 9 = 5
+			e2etest.WaitForCount(`tbody tr[data-key]`, 5, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Bookmarked URL did not restore state: %v", err)
+		}
+		// Verify sort order is date-desc: first row should be the newest completed item
+		// (ID 9, 2024-08-19) per filterDataset in data.go.
+		var firstRowHTML string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`tbody tr:first-child`, &firstRowHTML, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read first row: %v", err)
+		}
+		if !strings.Contains(firstRowHTML, "2024-08-19") {
+			t.Errorf("Expected newest completed item (2024-08-19) first, got:\n%s", firstRowHTML)
+		}
+		var navHTML string
+		err = chromedp.Run(ctx, chromedp.OuterHTML(`article nav`, &navHTML, chromedp.ByQuery))
+		if err != nil {
+			t.Fatalf("Failed to read nav: %v", err)
+		}
+		if !strings.Contains(navHTML, `aria-current="page">Completed`) {
+			t.Errorf("Completed link should be marked aria-current after bookmarked reload, got:\n%s", navHTML)
+		}
+		if !strings.Contains(navHTML, `aria-current="page">By Date`) {
+			t.Errorf("By Date link should be marked aria-current after bookmarked reload, got:\n%s", navHTML)
+		}
+	})
+
+	t.Run("Invalid_Status_Falls_Back", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL+"?status=nonsense&sort=date"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			// Unknown status falls back to default "all" → 12 items
+			e2etest.WaitForCount(`tbody tr[data-key]`, 12, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Invalid status did not fall back gracefully: %v", err)
+		}
+	})
+
+	t.Run("Reset_To_All", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`a[href="?status=all&sort=date"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, 12, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to reset to all: %v", err)
+		}
+	})
+}
+
+// --- Pattern #10: Infinite Scroll ---
+
+// TestInfiniteScroll verifies the #scroll-sentinel IntersectionObserver
+// wiring and the loadMorePending throttle. In headless Chrome the short
+// first page keeps the sentinel intersecting, so page 2 auto-advances;
+// subsequent pages require an explicit scroll because the sentinel has
+// drifted past the 200px rootMargin.
+func TestInfiniteScroll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/infinite-scroll"
+
+	t.Run("Initial_Load_And_Auto_Advance", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`table`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			// First page renders, observer auto-advances while sentinel is
+			// in view (safely throttled by the client's loadMorePending flag).
+			e2etest.WaitFor(`document.querySelectorAll('tbody tr[data-key]').length >= 10`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+		// Wait for the auto-advance to settle: two consecutive polls with
+		// the same row count (rows have stopped arriving).
+		var dataKeys string
+		err = chromedp.Run(ctx,
+			e2etest.WaitFor(`(() => {
+				const prev = window.__lastRowCount || 0;
+				const cur = document.querySelectorAll('tbody tr[data-key]').length;
+				window.__lastRowCount = cur;
+				return cur === prev && cur > 0;
+			})()`, 3*time.Second),
+			chromedp.Evaluate(`Array.from(document.querySelectorAll('tbody tr[data-key]')).map(r => r.getAttribute('data-key')).join(',')`, &dataKeys),
+		)
+		if err != nil {
+			t.Fatalf("Auto-advance did not settle: %v", err)
+		}
+		// Verify no duplicate data-keys — the client's loadMorePending flag
+		// plus the WS-aware connect() ensure that each load_more lands
+		// exactly once on the server-side persistent state path.
+		seen := make(map[string]bool)
+		for _, k := range strings.Split(dataKeys, ",") {
+			if seen[k] {
+				t.Fatalf("Duplicate data-key %q after auto-advance: %s", k, dataKeys)
+			}
+			seen[k] = true
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Infinite Scroll — table with 20 rows (ID, Name, Email) followed by a 'Loading more…' sentinel at the bottom")
+
+	t.Run("Scroll_Triggers_More_Pages", func(t *testing.T) {
+		// Scroll the sentinel into view repeatedly. Each scroll fires one
+		// observer callback (throttled by the client's loadMorePending flag),
+		// appending one more page. With the 100-item dataset at page size 10,
+		// we'd need ~8-10 scrolls to fully exhaust, so we verify the pipeline
+		// works by scrolling twice and confirming two extra pages loaded.
+		var baseline int
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`document.querySelectorAll('tbody tr[data-key]').length`, &baseline))
+		if baseline < 10 {
+			t.Fatalf("Baseline row count too low: %d", baseline)
+		}
+		// Scroll once
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`(() => {
+				const s = document.getElementById('scroll-sentinel');
+				if (s) s.scrollIntoView({ block: 'center' });
+			})()`, nil),
+			e2etest.WaitFor(`document.querySelectorAll('tbody tr[data-key]').length > `+fmt.Sprintf("%d", baseline), 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("First scroll did not trigger a new page: %v", err)
+		}
+		// Scroll again
+		var afterFirstScroll int
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`document.querySelectorAll('tbody tr[data-key]').length`, &afterFirstScroll))
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`(() => {
+				const s = document.getElementById('scroll-sentinel');
+				if (s) s.scrollIntoView({ block: 'center' });
+			})()`, nil),
+			e2etest.WaitFor(`document.querySelectorAll('tbody tr[data-key]').length > `+fmt.Sprintf("%d", afterFirstScroll), 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Second scroll did not trigger a new page: %v", err)
+		}
+		// Duplicate check: all data-keys are unique.
+		var dataKeys string
+		_ = chromedp.Run(ctx,
+			chromedp.Evaluate(`Array.from(document.querySelectorAll('tbody tr[data-key]')).map(r => r.getAttribute('data-key')).join(',')`, &dataKeys),
+		)
+		seen := make(map[string]bool)
+		for _, k := range strings.Split(dataKeys, ",") {
+			if seen[k] {
+				t.Errorf("Duplicate data-key %q after scroll-driven pagination: %s", k, dataKeys)
+			}
+			seen[k] = true
+		}
+		// Sanity: at least 3 items from past the first page should be present.
+		var html string
+		_ = chromedp.Run(ctx, chromedp.OuterHTML(`tbody`, &html, chromedp.ByQuery))
+		if !strings.Contains(html, "Row 1") {
+			t.Error("Row 1 (first item) missing after scroll")
 		}
 	})
 }

--- a/patterns/state_lists.go
+++ b/patterns/state_lists.go
@@ -1,0 +1,36 @@
+package main
+
+// DeleteRowState holds the state for the Delete Row pattern (#8).
+type DeleteRowState struct {
+	Title    string
+	Category string
+	Items    []Item
+}
+
+// ClickToLoadState holds the state for the Click To Load pattern (#9).
+type ClickToLoadState struct {
+	Title       string
+	Category    string
+	Items       []Item
+	CurrentPage int
+	HasMore     bool
+}
+
+// InfiniteScrollState holds the state for the Infinite Scroll pattern (#10).
+type InfiniteScrollState struct {
+	Title       string
+	Category    string
+	Items       []Item
+	CurrentPage int
+	HasMore     bool
+}
+
+// ValueSelectState holds the state for the Value Select pattern (#11).
+type ValueSelectState struct {
+	Title    string
+	Category string
+	Makes    []string
+	Models   []string
+	Make     string
+	Model    string
+}

--- a/patterns/state_search.go
+++ b/patterns/state_search.go
@@ -1,0 +1,18 @@
+package main
+
+// ActiveSearchState holds the state for the Active Search pattern (#12).
+type ActiveSearchState struct {
+	Title    string
+	Category string
+	Query    string
+	Results  []Contact
+}
+
+// URLFiltersState holds the state for the URL-Preserved Filters pattern (#13).
+type URLFiltersState struct {
+	Title    string
+	Category string
+	Status   string
+	Sort     string
+	Items    []FilterItem
+}

--- a/patterns/templates/forms/bulk-update.tmpl
+++ b/patterns/templates/forms/bulk-update.tmpl
@@ -17,5 +17,6 @@
         <button name="bulkUpdate">Update</button>
     </form>
     {{.lvt.FlashTag "success"}}
+    {{.lvt.FlashTag "info"}}
 </article>
 {{end}}

--- a/patterns/templates/forms/click-to-edit.tmpl
+++ b/patterns/templates/forms/click-to-edit.tmpl
@@ -25,7 +25,9 @@
             <tr><th>Email</th><td>{{.Email}}</td></tr>
         </tbody>
     </table>
-    <button name="edit" class="outline">Edit</button>
+    <form method="POST">
+        <button name="edit" class="outline">Edit</button>
+    </form>
     {{end}}
 </article>
 {{end}}

--- a/patterns/templates/forms/edit-row.tmpl
+++ b/patterns/templates/forms/edit-row.tmpl
@@ -9,11 +9,10 @@
             {{if eq $.EditingID .ID}}
             <td colspan="3">
                 <form method="POST" class="inline">
-                    <input type="hidden" name="id" value="{{.ID}}">
                     <fieldset role="group">
                         <input name="name" value="{{.Name}}">
                         <input name="email" value="{{.Email}}">
-                        <button name="save" class="compact">Save</button>
+                        <button name="save" value="{{.ID}}" class="compact">Save</button>
                         <button name="cancel" class="compact secondary">Cancel</button>
                     </fieldset>
                 </form>
@@ -23,8 +22,7 @@
             <td>{{.Email}}</td>
             <td>
                 <form method="POST" class="inline">
-                    <input type="hidden" name="id" value="{{.ID}}">
-                    <button name="edit" class="compact secondary outline">Edit</button>
+                    <button name="edit" value="{{.ID}}" class="compact secondary outline">Edit</button>
                 </form>
             </td>
             {{end}}

--- a/patterns/templates/lists/click-to-load.tmpl
+++ b/patterns/templates/lists/click-to-load.tmpl
@@ -1,0 +1,25 @@
+{{define "content"}}
+<article>
+    <h3>Click To Load</h3>
+    <p><small>Append-only pagination. Clicking Load More asks the server for the next page; the diff engine appends new rows without redrawing existing ones.</small></p>
+    <table>
+        <thead><tr><th>ID</th><th>Name</th><th>Email</th></tr></thead>
+        <tbody>
+        {{range .Items}}
+        <tr data-key="{{.ID}}">
+            <td>{{.ID}}</td>
+            <td>{{.Name}}</td>
+            <td>{{.Email}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{if .HasMore}}
+    <form method="POST">
+        <button name="loadMore" class="secondary outline">Load More</button>
+    </form>
+    {{else}}
+    <p><small>End of list.</small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/lists/delete-row.tmpl
+++ b/patterns/templates/lists/delete-row.tmpl
@@ -1,0 +1,30 @@
+{{define "content"}}
+<article>
+    <h3>Delete Row</h3>
+    <p><small>Click Delete on any row. New rows slide in via <code>lvt-fx:animate="slide"</code> (entry-only). Items live in a process-wide in-memory table, so deletions persist across reloads and navigation; use Restore to reset.</small></p>
+    {{if gt (len .Items) 0}}
+    <table>
+        <thead><tr><th>ID</th><th>Name</th><th>Email</th><th></th></tr></thead>
+        <tbody>
+        {{range .Items}}
+        <tr data-key="{{.ID}}" lvt-fx:animate="slide">
+            <td>{{.ID}}</td>
+            <td>{{.Name}}</td>
+            <td>{{.Email}}</td>
+            <td>
+                <form method="POST" class="inline">
+                    <button name="delete" value="{{.ID}}" class="compact contrast outline">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{else}}
+    <p><small>All items deleted.</small></p>
+    <form method="POST">
+        <button name="restore" class="secondary outline">Restore Items</button>
+    </form>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/lists/infinite-scroll.tmpl
+++ b/patterns/templates/lists/infinite-scroll.tmpl
@@ -1,0 +1,23 @@
+{{define "content"}}
+<article>
+    <h3>Infinite Scroll</h3>
+    <p><small>A single <code>&lt;div id="scroll-sentinel"&gt;</code> at the end of the list is watched by the client's IntersectionObserver. When it enters the viewport, the client dispatches <code>load_more</code> automatically — no client JS to wire up. Dataset has 100 items; scroll to watch pages append.</small></p>
+    <table>
+        <thead><tr><th>ID</th><th>Name</th><th>Email</th></tr></thead>
+        <tbody>
+        {{range .Items}}
+        <tr data-key="{{.ID}}">
+            <td>{{.ID}}</td>
+            <td>{{.Name}}</td>
+            <td>{{.Email}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{if .HasMore}}
+    <div id="scroll-sentinel"><small aria-busy="true">Loading more…</small></div>
+    {{else}}
+    <p><small>End of list.</small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/lists/value-select.tmpl
+++ b/patterns/templates/lists/value-select.tmpl
@@ -1,0 +1,27 @@
+{{define "content"}}
+<article>
+    <h3>Value Select</h3>
+    <p><small>Cascading dependent selects. The Change() handler auto-fires when the Make select changes and updates the Model options server-side — no client JS.</small></p>
+    <form method="POST">
+        <label>Make
+            <select name="make">
+                <option value="">Select Make</option>
+                {{range .Makes}}
+                <option value="{{.}}" {{if eq $.Make .}}selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+        </label>
+        <label>Model
+            <select name="model" {{if not .Make}}disabled{{end}}>
+                <option value="">Select Model</option>
+                {{range .Models}}
+                <option value="{{.}}" {{if eq $.Model .}}selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+        </label>
+    </form>
+    {{if .Model}}
+    <p>Selected: <strong>{{.Make}} {{.Model}}</strong></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/search/active-search.tmpl
+++ b/patterns/templates/search/active-search.tmpl
@@ -1,0 +1,25 @@
+{{define "content"}}
+<article>
+    <h3>Active Search</h3>
+    <p><small>Type in the search box. The Change() handler fires after a 300ms debounce and re-renders the result list server-side — no client-side filtering logic.</small></p>
+    <form method="POST">
+        <label>Search contacts
+            <input type="search" name="query" value="{{.Query}}" placeholder="Name or email…" autocomplete="off">
+        </label>
+    </form>
+    <table>
+        <thead><tr><th>Name</th><th>Email</th></tr></thead>
+        <tbody>
+        {{range .Results}}
+        <tr data-key="{{.ID}}">
+            <td>{{.Name}}</td>
+            <td>{{.Email}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{if and .Query (eq (len .Results) 0)}}
+    <p><small>No contacts match "<strong>{{.Query}}</strong>".</small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/search/url-filters.tmpl
+++ b/patterns/templates/search/url-filters.tmpl
@@ -1,0 +1,33 @@
+{{define "content"}}
+<article>
+    <h3>URL-Preserved Filters</h3>
+    <p><small>Filter state lives in the URL. SPA link clicks update history; direct-loading a bookmark restores the view. Mount() reads query params.</small></p>
+    <p><small>Current: status=<code>{{.Status}}</code>, sort=<code>{{.Sort}}</code></small></p>
+    <nav>
+        <ul>
+            <li><a href="?status=all&amp;sort={{.Sort}}" {{if eq .Status "all"}}aria-current="page"{{end}}>All</a></li>
+            <li><a href="?status=active&amp;sort={{.Sort}}" {{if eq .Status "active"}}aria-current="page"{{end}}>Active</a></li>
+            <li><a href="?status=completed&amp;sort={{.Sort}}" {{if eq .Status "completed"}}aria-current="page"{{end}}>Completed</a></li>
+        </ul>
+        <ul>
+            <li><a href="?status={{.Status}}&amp;sort=name" {{if eq .Sort "name"}}aria-current="page"{{end}}>By Name</a></li>
+            <li><a href="?status={{.Status}}&amp;sort=date" {{if eq .Sort "date"}}aria-current="page"{{end}}>By Date</a></li>
+        </ul>
+    </nav>
+    <table>
+        <thead><tr><th>Name</th><th>Status</th><th>Date</th></tr></thead>
+        <tbody>
+        {{range .Items}}
+        <tr data-key="{{.ID}}">
+            <td>{{.Name}}</td>
+            <td>{{.Status}}</td>
+            <td>{{.Date}}</td>
+        </tr>
+        {{end}}
+        </tbody>
+    </table>
+    {{if eq (len .Items) 0}}
+    <p><small>No items match this filter.</small></p>
+    {{end}}
+</article>
+{{end}}


### PR DESCRIPTION
## Summary

Implements Session 2 of the patterns example plan (livetemplate/livetemplate docs/proposals/patterns.md): Lists & Data (#8-11) and Search & Filtering (#12-13). Adds 6 new patterns as self-contained handler+template+state+tests, plus a Session 1 polish sweep for issues surfaced during manual review.

## New patterns

- **#8 Delete Row** — per-row delete with `lvt-fx:animate="slide"` entry animation. Controller holds a process-wide mutex-protected in-memory item store so deletions persist across reloads and navigation without needing `lvt:"persist"` struct tags. Includes a Restore button that repopulates the store.
- **#9 Click To Load** — button-driven pagination over a 25-item dataset (3 pages at size 10).
- **#10 Infinite Scroll** — `<div id="scroll-sentinel">`-driven pagination over a 100-item dataset, demonstrating the client's IntersectionObserver + `loadMorePending` throttle.
- **#11 Value Select** — cascading Make/Model selects via `Change()` auto-wiring. Changing Make auto-selects the first Model so the cascade is visibly propagated.
- **#12 Active Search** — debounced live search over a 25-contact directory, using `Change()` on `<input type="search">`.
- **#13 URL-Preserved Filters** — bookmarkable filter state via URL query parameters, read in `Mount()` with graceful fallback for unknown values. Validates status ∈ {all, active, completed} and sort ∈ {name, date}.

All 6 patterns follow the Session 1 conventions: per-category state_*.go and handlers_*.go files, `{{define "content"}}` templates extending layout.tmpl, `data-key` on range items, chromedp E2E tests with Initial_Load / UI_Standards / Visual_Check subtests plus action-specific coverage.

## Session 1 polish sweep

- **Edit Row**: dropped hidden-input ID pattern in favor of button `value` attribute (`<button name="edit" value="{{.ID}}">` → `ctx.GetString("value")`), matching the documented Tier 1 pattern in progressive-complexity-reference.md. Same change applied to Delete Row's new template.
- **Click To Edit**: wrapped view-mode Edit button in a form for Tier 1 no-JS compliance (fixes Session 1 tracker issue #66).
- **Bulk Update**: fixed spurious \"Updated N user(s)\" flash always reporting the total user count. Now counts actual checkbox changes and shows a \"No changes\" info flash when none changed. Added `{{.lvt.FlashTag \"info\"}}` to the template since only success was previously rendered.

## Cross-handler navigation regression test

Added `TestCrossHandlerNavigation/Index_To_Delete_Row_No_Stale_Dom` to lock in DOM structure (article/h4/row counts) after index→pattern navigation, catching treeRenderer state-leak bugs that pre-existing string-contains assertions miss. This test fails against the current published client; it passes against [livetemplate/client#69](https://github.com/livetemplate/client/pull/69).

## Infrastructure

- `runStandardSubtests(t, ctx, pico, desc)` helper consolidates 12 copy-pasted `UI_Standards` + `Visual_Check` subtest pairs across Session 1 and Session 2 tests. Delete Row retains its hand-rolled `UI_Standards` because it needs an animation-wait precheck.
- Data layer cleanup: `buildItemDataset(n, prefix)` shared builder for `listDataset` (25) and `infiniteScrollDataset` (100); `slices.Clone` everywhere replacing manual make+copy idioms; `slices.Sorted(maps.Keys)` for `getCarMakes`; hoisted `contactDirectory` to package-level var.

## Dependency

⚠️ **CI will fail until [livetemplate/client#69](https://github.com/livetemplate/client/pull/69) is merged and released.** Examples CI runs against `@latest` client from CDN, and this PR exercises cross-handler navigation, infinite scroll, and slide-in animation behavior that depend on client fixes in that PR. Locally, all 15 tests pass against the client PR's build via `LVT_LOCAL_CLIENT`.

Review/merge order: review this PR → review+merge client PR → run `./scripts/release.sh` in client → examples CI re-runs → review+merge this PR.

## Test plan

- [ ] Wait for client PR #69 to merge and release
- [ ] CI re-runs against new @latest client, all 15 tests pass
- [ ] Manual verification of each new pattern page works in browser
- [ ] Update Session 2 checkboxes in docs/proposals/patterns.md (separate commit in livetemplate/livetemplate repo, after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)