### PR TITLE
ci(claude-review): replace plugin invocation with inline gh pr comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,23 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: copilot-swe-agent
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Why

The `Claude Code Review` workflow on this repo had not been posting review comments on any PR — the workflow ran successfully (job returned exit 0) but no comment ever appeared. Investigation on [#70](https://github.com/livetemplate/examples/pull/70) found two contributing problems.

## Problem 1: Plugin-based prompt silently no-ops

The workflow used a plugin-based prompt invocation:

```yaml
plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
plugins: 'code-review@claude-code-plugins'
prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
```

The `code-review@claude-code-plugins` plugin appears to either suppress its review output entirely or use an internal posting path that does not work with the GitHub App token context the action provides. The job step returns success but no PR comment ever appears.

Compare to the [livetemplate library workflow](https://github.com/livetemplate/livetemplate/blob/main/.github/workflows/claude-code-review.yml), which uses an **inline prompt + explicit `gh pr comment` instruction**. With that approach, Claude generates the review, then runs `gh pr comment` itself via its Bash tool (using the GH App installation token that the Claude Code Action injects into the runner's environment). This has been working continuously on the library repo and produced 4 review comments across the recent rounds of [livetemplate/livetemplate#336](https://github.com/livetemplate/livetemplate/pull/336).

## Problem 2: Workflow validation against default branch blocks in-PR fixes

The Claude Code Action validates the PR's workflow file against the default branch's copy as a security mitigation. Any in-PR change to `claude-code-review.yml` itself fails with:

```
App token exchange failed: 401 Unauthorized — Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
```

This is a legitimate security boundary — without it, anyone with push access to the repo could open a one-line PR that modifies the workflow to inject `gh repo set` or arbitrary commands, then trigger the Claude Code Action to execute them with the GH App's elevated token.

The implication is that **the fix has to land on main first via this dedicated PR** before it takes effect on any other PR. We can't validate the change inside an existing feature PR.

## Changes

- Drop `plugin_marketplaces`, `plugins`, and the slash-command `prompt`
- Add inline prompt with explicit "Use `gh pr comment`" instruction (verbatim from the library workflow, with `REPO` / `PR NUMBER` interpolation)
- Add `claude_args` with allow-list for: `gh issue view`, `gh search`, `gh issue list`, `gh pr comment`, `gh pr diff`, `gh pr view`, `gh pr list`
- Add `allowed_bots: copilot-swe-agent` (matches library config; lets Claude interact with Copilot comments on the same PR)

**Trigger types are preserved unchanged** (`opened, synchronize, ready_for_review, reopened`) — no functional reason to align them with the library's narrower set.

## After this merges

- Future PRs to `livetemplate/examples` will get real Claude review comments within ~5–8 minutes of each push
- [livetemplate/examples#70](https://github.com/livetemplate/examples/pull/70) (Session 3 patterns) will pick up the new workflow on its next push or workflow rerun, finally allowing Claude to review the Session 3 code (Copilot has already reviewed it; Claude has been silent because of this bug)

## Test plan

This PR can't really be tested in isolation — the workflow is only triggered by `pull_request` events, and the only `pull_request` event for this PR is the PR-itself event. The first real validation will happen on the **next PR** to land after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)