### PR TITLE
fix(dialog-patterns): field-level validation inside open dialogs

### DIFF
--- a/dialog-patterns/dialog-patterns.tmpl
+++ b/dialog-patterns/dialog-patterns.tmpl
@@ -63,7 +63,7 @@
             <form name="add">
                 <label>
                     Title
-                    <input name="title" required minlength="3" placeholder="Enter item title" {{.lvt.AriaInvalid "title"}}>
+                    <input name="title" required placeholder="Enter item title" {{.lvt.AriaInvalid "title"}}>
                     {{.lvt.ErrorTag "title"}}
                 </label>
                 <footer>

--- a/dialog-patterns/dialog-patterns.tmpl
+++ b/dialog-patterns/dialog-patterns.tmpl
@@ -63,7 +63,8 @@
             <form name="add">
                 <label>
                     Title
-                    <input name="title" required placeholder="Enter item title">
+                    <input name="title" required minlength="3" placeholder="Enter item title" {{.lvt.AriaInvalid "title"}}>
+                    {{.lvt.ErrorTag "title"}}
                 </label>
                 <footer>
                     <fieldset role="group">

--- a/dialog-patterns/dialog_patterns_test.go
+++ b/dialog-patterns/dialog_patterns_test.go
@@ -279,14 +279,9 @@ func TestDialogPatternsE2E(t *testing.T) {
 			t.Fatalf("Failed to open dialog: %v", err)
 		}
 
-		// The input has `required` and `minlength`, so browser validation prevents
-		// empty submission. Remove both via JS to test server-side validation.
+		// Remove `required` via JS so the empty form reaches the server for validation.
 		err = chromedp.Run(ctx,
-			chromedp.Evaluate(`(() => {
-				const inp = document.querySelector('dialog#add-dialog input[name="title"]');
-				inp.removeAttribute('required');
-				inp.removeAttribute('minlength');
-			})()`, nil),
+			chromedp.Evaluate(`document.querySelector('dialog#add-dialog input[name="title"]').removeAttribute('required')`, nil),
 			chromedp.Clear(`dialog#add-dialog input[name="title"]`, chromedp.ByQuery),
 			chromedp.Click(`dialog#add-dialog button[type="submit"]`, chromedp.ByQuery),
 			e2etest.WaitFor(`document.querySelector('dialog#add-dialog small') !== null`, 10*time.Second),

--- a/dialog-patterns/dialog_patterns_test.go
+++ b/dialog-patterns/dialog_patterns_test.go
@@ -279,16 +279,57 @@ func TestDialogPatternsE2E(t *testing.T) {
 			t.Fatalf("Failed to open dialog: %v", err)
 		}
 
-		// The input has `required`, so browser validation prevents empty submission.
-		// Remove `required` via JS to test server-side validation.
+		// The input has `required` and `minlength`, so browser validation prevents
+		// empty submission. Remove both via JS to test server-side validation.
 		err = chromedp.Run(ctx,
-			chromedp.Evaluate(`document.querySelector('dialog#add-dialog input[name="title"]').removeAttribute('required')`, nil),
+			chromedp.Evaluate(`(() => {
+				const inp = document.querySelector('dialog#add-dialog input[name="title"]');
+				inp.removeAttribute('required');
+				inp.removeAttribute('minlength');
+			})()`, nil),
 			chromedp.Clear(`dialog#add-dialog input[name="title"]`, chromedp.ByQuery),
 			chromedp.Click(`dialog#add-dialog button[type="submit"]`, chromedp.ByQuery),
-			e2etest.WaitFor(`true`, 2*time.Second), // wait for server response
+			e2etest.WaitFor(`document.querySelector('dialog#add-dialog small') !== null`, 10*time.Second),
 		)
 		if err != nil {
-			t.Fatalf("Failed to submit empty form: %v", err)
+			t.Fatalf("Failed to submit empty form or validation error not shown: %v", err)
+		}
+
+		// Dialog should stay open while showing validation errors
+		var dialogOpen bool
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.getElementById('add-dialog').open`, &dialogOpen),
+		)
+		if err != nil {
+			t.Fatalf("Failed to check dialog state: %v", err)
+		}
+		if !dialogOpen {
+			t.Error("Dialog should remain open when showing validation errors")
+		}
+
+		// Validation error <small> tag should be visible inside the dialog
+		var errorText string
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('dialog#add-dialog small').textContent`, &errorText),
+		)
+		if err != nil {
+			t.Fatalf("Failed to read error text: %v", err)
+		}
+		if errorText == "" {
+			t.Error("Validation error message should not be empty")
+		}
+		t.Logf("Validation error shown: %q", errorText)
+
+		// Input should have aria-invalid="true"
+		var ariaInvalid string
+		err = chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('dialog#add-dialog input[name="title"]').getAttribute('aria-invalid')`, &ariaInvalid),
+		)
+		if err != nil {
+			t.Fatalf("Failed to check aria-invalid: %v", err)
+		}
+		if ariaInvalid != "true" {
+			t.Errorf("Input should have aria-invalid='true', got %q", ariaInvalid)
 		}
 
 		// Item count should remain 3 (unchanged — fresh session has seed items)
@@ -301,7 +342,7 @@ func TestDialogPatternsE2E(t *testing.T) {
 			t.Error("Item count should still be '3 items' after failed empty submission")
 		}
 
-		t.Log("✅ Empty title submission rejected by server, item count unchanged")
+		t.Log("✅ Validation errors shown inside open dialog, item count unchanged")
 	})
 
 	t.Run("Delete_Item", func(t *testing.T) {

--- a/dialog-patterns/main.go
+++ b/dialog-patterns/main.go
@@ -10,9 +10,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/livetemplate/livetemplate"
 	e2etest "github.com/livetemplate/lvt/testing"
 )
+
+var validate = validator.New()
 
 type DialogController struct{}
 
@@ -23,6 +26,10 @@ type DialogState struct {
 type Item struct {
 	ID    string
 	Title string
+}
+
+type AddInput struct {
+	Title string `json:"title" validate:"required,min=3"`
 }
 
 func (c *DialogController) Mount(state DialogState, ctx *livetemplate.Context) (DialogState, error) {
@@ -37,12 +44,12 @@ func (c *DialogController) Mount(state DialogState, ctx *livetemplate.Context) (
 }
 
 func (c *DialogController) Add(state DialogState, ctx *livetemplate.Context) (DialogState, error) {
-	title := ctx.GetString("title")
-	if title == "" {
-		return state, fmt.Errorf("title is required")
+	var input AddInput
+	if err := ctx.BindAndValidate(&input, validate); err != nil {
+		return state, err
 	}
 	id := fmt.Sprintf("%d", time.Now().UnixNano())
-	state.Items = append(state.Items, Item{ID: id, Title: title})
+	state.Items = append(state.Items, Item{ID: id, Title: input.Title})
 	return state, nil
 }
 


### PR DESCRIPTION
## Summary
- Switch dialog-patterns example from manual `ctx.GetString` + `fmt.Errorf` to `ctx.BindAndValidate` with validator struct tags
- Add `{{.lvt.AriaInvalid "title"}}` and `{{.lvt.ErrorTag "title"}}` to render field-level validation errors inside the open dialog
- Remove `minlength` from template so server-side validation can be tested manually (type "ab" → see error)
- Update E2E test to assert `<small>` error tag, `aria-invalid="true"`, and dialog staying open on validation failure

**Depends on:** livetemplate/client#93 (must be merged + published first)

## Test plan
- [x] All 7 dialog-patterns E2E subtests pass with patched client
- [x] Manual browser test: validation error renders inside open dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)