### PR TITLE
feat: patterns example Session 4 (patterns #17-21) — dialogs, tabs & navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ live-preview/live-preview
 todos-progressive/todos-progressive
 profile-progressive/profile-progressive
 shared-notepad/shared-notepad
+patterns/patterns
 .worktrees/

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.8.19-0.20260416045141-cdf29dd5e5cc
+	github.com/livetemplate/livetemplate v0.8.21
 	github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074
 	github.com/livetemplate/lvt/components v0.1.2
 	modernc.org/sqlite v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.8.19-0.20260416045141-cdf29dd5e5cc h1:W62+kCNLLfB8T2P4lgt+bpLEzG0KwxHk1lCAzc63JJA=
-github.com/livetemplate/livetemplate v0.8.19-0.20260416045141-cdf29dd5e5cc/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.8.21 h1:/c1EpxbiTkgOzi4L4KaZYCaL3Iu+kQeh4dGKAvYmfoA=
+github.com/livetemplate/livetemplate v0.8.21/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074 h1:0YYh5Uc0bTTc6f8A66G91Fm213UwaexO81O7meTjscE=
 github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074/go.mod h1:17cFl500ntymD3gx8h+ZODnVnTictHgG8Wmz/By75sU=
 github.com/livetemplate/lvt/components v0.1.2 h1:MM2M5IZnsUAu0py9ZbtcQCo0bvUrL4Z3Ly/yDkYNyag=

--- a/patterns/cross_handler_nav_test.go
+++ b/patterns/cross_handler_nav_test.go
@@ -329,53 +329,25 @@ func TestCrossHandlerNavigation(t *testing.T) {
 			t.Fatalf("Index → Modal Dialog navigation failed: %v", err)
 		}
 		var leakedText string
-		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => {
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`(() => {
 			const wrapper = document.querySelector('[data-lvt-id]');
 			if (!wrapper) return "no-wrapper";
 			const text = wrapper.textContent || "";
 			const leaks = ["Forms & Editing", "Lists & Data", "Search & Filtering", "Loading & Progress", "Visual Feedback", "Real-Time"];
 			return leaks.find(s => text.includes(s)) || "";
-		})()`, &leakedText))
+		})()`, &leakedText)); err != nil {
+			t.Fatalf("Leak-detection script failed to evaluate: %v", err)
+		}
+		if leakedText == "no-wrapper" {
+			t.Fatalf("Wrapper element [data-lvt-id] not found after navigation")
+		}
 		if leakedText != "" {
 			t.Errorf("Stale index category text %q leaked into Modal Dialog wrapper", leakedText)
 		}
 	})
 
-	t.Run("Tabs_Same_Pathname_Uses_WebSocket", func(t *testing.T) {
-		// On the Tabs pattern, clicking a tab link is a same-pathname
-		// query-string change. The client routes it via WebSocket
-		// (__navigate__) instead of an HTTP fetch — verify by overriding
-		// window.fetch and counting hits during the click.
-		err := chromedp.Run(ctx,
-			chromedp.Navigate(baseURL+"/patterns/navigation/tabs"),
-			e2etest.WaitForWebSocketReady(5*time.Second),
-			chromedp.WaitVisible(`a[href="?tab=overview"][aria-current="page"]`, chromedp.ByQuery),
-			chromedp.Evaluate(`(() => {
-				window.__crossNavHits = 0;
-				window.__origCrossFetch = window.fetch;
-				window.fetch = function(input, init) {
-					try {
-						const u = typeof input === 'string' ? input : input.url;
-						if (u && u.includes('/patterns/navigation/tabs')) window.__crossNavHits++;
-					} catch (e) {}
-					return window.__origCrossFetch.apply(window, arguments);
-				};
-			})()`, nil),
-			chromedp.Click(`a[href="?tab=settings"]`, chromedp.ByQuery),
-			e2etest.WaitFor(`!!document.querySelector('a[href="?tab=settings"][aria-current="page"]')`, 5*time.Second),
-		)
-		if err != nil {
-			t.Fatalf("Tab switch failed: %v", err)
-		}
-		var hits int
-		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__crossNavHits`, &hits)); err != nil {
-			t.Fatalf("HTTP hit count read failed: %v", err)
-		}
-		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origCrossFetch; })()`, nil))
-		if hits != 0 {
-			t.Errorf("Tab switch must use WebSocket __navigate__, got %d HTTP hits", hits)
-		}
-	})
+	// Tabs same-pathname __navigate__ is covered by
+	// TestTabs/Tab_Switch_Uses_WebSocket_Not_HTTP in patterns_test.go.
 
 	t.Run("SPA_Navigation_Cross_Pathname_Reconnects", func(t *testing.T) {
 		// From the SPA Navigation page, clicking a cross-pathname link to

--- a/patterns/cross_handler_nav_test.go
+++ b/patterns/cross_handler_nav_test.go
@@ -313,12 +313,11 @@ func TestCrossHandlerNavigation(t *testing.T) {
 	})
 
 	t.Run("Index_To_Modal_Dialog_No_Stale_Dom", func(t *testing.T) {
-		// Regression: navigating from index to a Session 4 navigation pattern
-		// must not leak any index-page category names ("Forms & Editing",
-		// "Lists & Data", etc.) into the new pattern's wrapper. The category
-		// strings are specific enough that any presence is a regression
-		// signal — Modal Dialog renders its own h4 ("Edit profile") inside
-		// the dialog, so a raw h4-count check would false-positive.
+		// Regression: navigating from index to a navigation pattern must
+		// not leak the index page's category names ("Forms & Editing",
+		// "Lists & Data", etc.) into the new pattern's wrapper. We check
+		// for those specific strings rather than counting <h4>s — Modal
+		// Dialog has its own legitimate h4 inside the dialog.
 		err := chromedp.Run(ctx,
 			chromedp.Navigate(baseURL),
 			e2etest.WaitForWebSocketReady(5*time.Second),

--- a/patterns/cross_handler_nav_test.go
+++ b/patterns/cross_handler_nav_test.go
@@ -312,6 +312,104 @@ func TestCrossHandlerNavigation(t *testing.T) {
 		}
 	})
 
+	t.Run("Index_To_Modal_Dialog_No_Stale_Dom", func(t *testing.T) {
+		// Regression: navigating from index to a Session 4 navigation pattern
+		// must not leak any index-page category names ("Forms & Editing",
+		// "Lists & Data", etc.) into the new pattern's wrapper. The category
+		// strings are specific enough that any presence is a regression
+		// signal — Modal Dialog renders its own h4 ("Edit profile") inside
+		// the dialog, so a raw h4-count check would false-positive.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`h2`, chromedp.ByQuery),
+			chromedp.Click(`a[href="/patterns/navigation/modal-dialog"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Modal Dialog", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Index → Modal Dialog navigation failed: %v", err)
+		}
+		var leakedText string
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => {
+			const wrapper = document.querySelector('[data-lvt-id]');
+			if (!wrapper) return "no-wrapper";
+			const text = wrapper.textContent || "";
+			const leaks = ["Forms & Editing", "Lists & Data", "Search & Filtering", "Loading & Progress", "Visual Feedback", "Real-Time"];
+			return leaks.find(s => text.includes(s)) || "";
+		})()`, &leakedText))
+		if leakedText != "" {
+			t.Errorf("Stale index category text %q leaked into Modal Dialog wrapper", leakedText)
+		}
+	})
+
+	t.Run("Tabs_Same_Pathname_Uses_WebSocket", func(t *testing.T) {
+		// On the Tabs pattern, clicking a tab link is a same-pathname
+		// query-string change. The client routes it via WebSocket
+		// (__navigate__) instead of an HTTP fetch — verify by overriding
+		// window.fetch and counting hits during the click.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL+"/patterns/navigation/tabs"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="?tab=overview"][aria-current="page"]`, chromedp.ByQuery),
+			chromedp.Evaluate(`(() => {
+				window.__crossNavHits = 0;
+				window.__origCrossFetch = window.fetch;
+				window.fetch = function(input, init) {
+					try {
+						const u = typeof input === 'string' ? input : input.url;
+						if (u && u.includes('/patterns/navigation/tabs')) window.__crossNavHits++;
+					} catch (e) {}
+					return window.__origCrossFetch.apply(window, arguments);
+				};
+			})()`, nil),
+			chromedp.Click(`a[href="?tab=settings"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('a[href="?tab=settings"][aria-current="page"]')`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Tab switch failed: %v", err)
+		}
+		var hits int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__crossNavHits`, &hits)); err != nil {
+			t.Fatalf("HTTP hit count read failed: %v", err)
+		}
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origCrossFetch; })()`, nil))
+		if hits != 0 {
+			t.Errorf("Tab switch must use WebSocket __navigate__, got %d HTTP hits", hits)
+		}
+	})
+
+	t.Run("SPA_Navigation_Cross_Pathname_Reconnects", func(t *testing.T) {
+		// From the SPA Navigation page, clicking a cross-pathname link to
+		// another pattern must change the wrapper's data-lvt-id (the new
+		// handler is a separate handler, so it gets a fresh wrapper id) and
+		// surface the new pattern's content.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(baseURL+"/patterns/navigation/spa-navigation"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="/patterns/navigation/tabs"]`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load SPA Navigation page: %v", err)
+		}
+		var oldID, newID string
+		err = chromedp.Run(ctx,
+			chromedp.AttributeValue(`[data-lvt-id]`, "data-lvt-id", &oldID, nil, chromedp.ByQuery),
+			chromedp.Click(`a[href="/patterns/navigation/tabs"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h3`, "Tabs (HATEOAS)", 10*time.Second),
+			e2etest.WaitForWebSocketReady(10*time.Second),
+			chromedp.AttributeValue(`[data-lvt-id]`, "data-lvt-id", &newID, nil, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Cross-pathname click + reconnect failed: %v", err)
+		}
+		if oldID == "" || newID == "" {
+			t.Errorf("data-lvt-id values should be present (old=%q, new=%q)", oldID, newID)
+		}
+		if oldID == newID {
+			t.Errorf("Cross-pathname navigation must reconnect with a fresh wrapper id; got same id %q before and after", oldID)
+		}
+	})
+
 	t.Run("WebSocket_Works_After_Navigation", func(t *testing.T) {
 		// Start fresh at index
 		err := chromedp.Run(ctx,

--- a/patterns/data.go
+++ b/patterns/data.go
@@ -266,11 +266,11 @@ func allPatterns() []PatternCategory {
 		{
 			Name: "Dialogs, Tabs & Navigation",
 			Patterns: []PatternLink{
-				{Name: "Modal Dialog", Path: "/patterns/navigation/modal-dialog", Description: "Native dialog with command/commandfor"},
-				{Name: "Confirm Dialog", Path: "/patterns/navigation/confirm-dialog", Description: "CSP-compliant confirmation flow"},
-				{Name: "Tabs (HATEOAS)", Path: "/patterns/navigation/tabs", Description: "Server-driven tabs via SPA navigation"},
-				{Name: "SPA Navigation", Path: "/patterns/navigation/spa-navigation", Description: "Auto link interception with pushState"},
-				{Name: "Keyboard Shortcuts", Path: "/patterns/navigation/keyboard-shortcuts", Description: "Global keyboard event binding"},
+				{Name: "Modal Dialog", Path: "/patterns/navigation/modal-dialog", Description: "Native dialog with command/commandfor", Implemented: true},
+				{Name: "Confirm Dialog", Path: "/patterns/navigation/confirm-dialog", Description: "CSP-compliant confirmation flow", Implemented: true},
+				{Name: "Tabs (HATEOAS)", Path: "/patterns/navigation/tabs", Description: "Server-driven tabs via SPA navigation", Implemented: true},
+				{Name: "SPA Navigation", Path: "/patterns/navigation/spa-navigation", Description: "Auto link interception with pushState", Implemented: true},
+				{Name: "Keyboard Shortcuts", Path: "/patterns/navigation/keyboard-shortcuts", Description: "Global keyboard event binding", Implemented: true},
 			},
 		},
 		{

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -68,6 +68,8 @@ func (c *ConfirmDialogController) Mount(state ConfirmDialogState, ctx *livetempl
 func (c *ConfirmDialogController) Delete(state ConfirmDialogState, ctx *livetemplate.Context) (ConfirmDialogState, error) {
 	// "value" is the framework key for the clicked submit button's value
 	// attribute (independent of the button's name). Same idiom as dialog-patterns.
+	// id is a server-rendered Item.ID echoed back via the form, NOT free-form
+	// user input — no escaping/allowlist check is needed.
 	id := ctx.GetString("value")
 	// Unknown ids are tolerated as a no-op — the next render reconciles any
 	// drift between client and server item lists without surfacing a flash.

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/livetemplate/livetemplate"
+)
+
+// validateNav is a single per-process validator instance shared by all
+// navigation-category controllers that use BindAndValidate. The validator
+// package recommends a singleton because internal struct/field caches are
+// computed lazily on first access.
+var validateNav = validator.New()
+
+// --- Pattern #17: Modal Dialog ---
+
+// ModalDialogController demonstrates a native <dialog> element triggered via
+// the Invoker Commands API (command/commandfor). The form inside the dialog
+// uses BindAndValidate so invalid submissions surface field-scoped errors via
+// {{.lvt.ErrorTag}} that render INSIDE the still-open dialog — exercising the
+// client v0.8.33 morphdom fix that allows child updates inside open dialogs.
+//
+// On a successful save the framework's diff updates the dialog wrapper and
+// the browser closes the dialog as part of normal form-submit handling; the
+// success flash then becomes visible on the page beneath the trigger button.
+type ModalDialogController struct{}
+
+// modalDialogInput mirrors the form fields. Validator tags drive the
+// per-field error messages that {{.lvt.ErrorTag "name"}} renders inside the
+// dialog when validation fails.
+type modalDialogInput struct {
+	Name  string `json:"name"  validate:"required,min=3"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+func (c *ModalDialogController) Save(state ModalDialogState, ctx *livetemplate.Context) (ModalDialogState, error) {
+	var in modalDialogInput
+	if err := ctx.BindAndValidate(&in, validateNav); err != nil {
+		return state, err
+	}
+	state.Name = in.Name
+	state.Email = in.Email
+	state.SavedAt = time.Now().Format("15:04:05")
+	ctx.SetFlash("success", "Profile saved", livetemplate.FlashExpiry(5*time.Second))
+	return state, nil
+}
+
+func modalDialogHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/navigation/modal-dialog.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ModalDialogController{}, livetemplate.AsState(&ModalDialogState{
+		Title:    "Modal Dialog",
+		Category: "Dialogs, Tabs & Navigation",
+		Name:     "Ada Lovelace",
+		Email:    "ada@analytical.engine",
+	}))
+}
+
+// --- Pattern #18: Confirm Dialog ---
+
+// ConfirmDialogController demonstrates a CSP-compliant confirmation flow: each
+// row owns its own <dialog id="confirm-{{.ID}}"> opened via command="show-modal"
+// commandfor="confirm-{{.ID}}". The Delete action reads the item id from the
+// submit button's value attribute, NOT a hidden input — see CLAUDE.md and the
+// patterns proposal for the rationale ("button name=delete value={{.ID}}").
+//
+// Items live on the controller (singleton, never cloned) behind a sync.Mutex,
+// so deletes persist across page reloads within a process. We don't use one
+// here because demo cardinality is small (5 items) and the user-visible
+// "Restore" button is intentionally absent — refreshing reseeds.
+type ConfirmDialogController struct{}
+
+const confirmDialogItemCount = 5
+
+func (c *ConfirmDialogController) Mount(state ConfirmDialogState, ctx *livetemplate.Context) (ConfirmDialogState, error) {
+	if len(state.Items) == 0 && ctx.Action() == "" {
+		state.Items = getItemPage(1, confirmDialogItemCount)
+	}
+	return state, nil
+}
+
+func (c *ConfirmDialogController) Delete(state ConfirmDialogState, ctx *livetemplate.Context) (ConfirmDialogState, error) {
+	id := ctx.GetString("value")
+	state.Items = slices.DeleteFunc(state.Items, func(it Item) bool { return it.ID == id })
+	return state, nil
+}
+
+func confirmDialogHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/navigation/confirm-dialog.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ConfirmDialogController{}, livetemplate.AsState(&ConfirmDialogState{
+		Title:    "Confirm Dialog",
+		Category: "Dialogs, Tabs & Navigation",
+	}))
+}
+
+// --- Pattern #19: Tabs (HATEOAS) ---
+
+// TabsController is Mount-only. Tab clicks are <a href="?tab=…"> which the
+// client routes through the WebSocket as the reserved __navigate__ action
+// (library v0.8.19+, client v0.8.26+). The server re-runs Mount() with the
+// new query params; ctx.Action() returns "" inside that re-run (the action
+// loop sets it via WithAction("")), so the same `if ctx.Action() == ""`
+// guard used on initial GET also runs on tab switches. Compare to Pattern
+// #13 (URL-Preserved Filters) which uses the same shape.
+type TabsController struct{}
+
+var validTabs = map[string]bool{"overview": true, "settings": true, "activity": true}
+
+func (c *TabsController) Mount(state TabsState, ctx *livetemplate.Context) (TabsState, error) {
+	if ctx.Action() == "" {
+		if t := ctx.GetString("tab"); validTabs[t] {
+			state.ActiveTab = t
+		} else if state.ActiveTab == "" {
+			state.ActiveTab = "overview"
+		}
+	}
+	return state, nil
+}
+
+func tabsHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/navigation/tabs.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&TabsController{}, livetemplate.AsState(&TabsState{
+		Title:    "Tabs (HATEOAS)",
+		Category: "Dialogs, Tabs & Navigation",
+	}))
+}
+
+// --- Pattern #20: SPA Navigation ---
+
+// SPANavController demonstrates the framework's automatic link interception:
+// same-pathname query-string changes use the in-band __navigate__ action over
+// WebSocket, while cross-pathname links trigger a full reconnect. The Step
+// counter ([1, 3]) showcases the same-pathname path; cross-pathname is shown
+// via links to other pattern handlers; lvt-nav:no-intercept is shown via an
+// external link.
+type SPANavController struct{}
+
+const spaNavMaxStep = 3
+
+func (c *SPANavController) Mount(state SPANavState, ctx *livetemplate.Context) (SPANavState, error) {
+	if ctx.Action() == "" {
+		if s := ctx.GetString("step"); s != "" {
+			if n, err := strconv.Atoi(s); err == nil && n >= 1 && n <= spaNavMaxStep {
+				state.Step = n
+			}
+		}
+		if state.Step == 0 {
+			state.Step = 1
+		}
+	}
+	return state, nil
+}
+
+func spaNavigationHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/navigation/spa-navigation.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&SPANavController{}, livetemplate.AsState(&SPANavState{
+		Title:    "SPA Navigation",
+		Category: "Dialogs, Tabs & Navigation",
+	}))
+}
+
+// --- Pattern #21: Keyboard Shortcuts ---
+
+// ShortcutsController is Tier-2: it uses lvt-on:window:keydown bindings to
+// drive a command-palette-style overlay. Open binds "/", Close binds "Escape"
+// inside the open panel. A small ring buffer of activity log entries doubles
+// as visual feedback in the rendered HTML — handy for the e2e tests since
+// the panel state can be confirmed without screen-scraping the overlay.
+type ShortcutsController struct{}
+
+const shortcutsLogMax = 5
+
+func (c *ShortcutsController) Open(state ShortcutsState, ctx *livetemplate.Context) (ShortcutsState, error) {
+	if state.PanelOpen {
+		return state, nil
+	}
+	state.PanelOpen = true
+	state.Log = appendLog(state.Log, fmt.Sprintf("[%s] Opened panel", time.Now().Format("15:04:05")))
+	return state, nil
+}
+
+func (c *ShortcutsController) Close(state ShortcutsState, ctx *livetemplate.Context) (ShortcutsState, error) {
+	if !state.PanelOpen {
+		return state, nil
+	}
+	state.PanelOpen = false
+	state.Log = appendLog(state.Log, fmt.Sprintf("[%s] Closed panel", time.Now().Format("15:04:05")))
+	return state, nil
+}
+
+func appendLog(log []string, entry string) []string {
+	log = append(log, entry)
+	if len(log) > shortcutsLogMax {
+		log = log[len(log)-shortcutsLogMax:]
+	}
+	return log
+}
+
+func keyboardShortcutsHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/navigation/keyboard-shortcuts.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&ShortcutsController{}, livetemplate.AsState(&ShortcutsState{
+		Title:    "Keyboard Shortcuts",
+		Category: "Dialogs, Tabs & Navigation",
+	}))
+}

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -13,7 +13,13 @@ import (
 
 // validateNav is the per-process validator shared by navigation-category
 // controllers. The validator package caches struct/field metadata internally,
-// so a single instance is faster than constructing one per request.
+// so a singleton is faster than constructing one per request.
+//
+// We use BindAndValidate (not ctx.ValidateForm) for Modal Dialog because
+// ExtractFormSchema's HTML5-attribute parsing does not currently surface a
+// form schema for forms inside a <dialog>; the explicit struct + validator
+// tags is the same shape used by examples/dialog-patterns and works reliably
+// across all form-positioning cases.
 var validateNav = validator.New()
 
 // --- Pattern #17: Modal Dialog ---
@@ -102,9 +108,10 @@ var validTabs = map[string]bool{"overview": true, "settings": true, "activity": 
 
 func (c *TabsController) Mount(state TabsState, ctx *livetemplate.Context) (TabsState, error) {
 	if ctx.Action() == "" {
-		if t := ctx.GetString("tab"); validTabs[t] {
+		t := ctx.GetString("tab")
+		if t != "" && validTabs[t] {
 			state.ActiveTab = t
-		} else if state.ActiveTab == "" {
+		} else if t != "" || !validTabs[state.ActiveTab] {
 			state.ActiveTab = "overview"
 		}
 	}

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -11,24 +11,13 @@ import (
 	"github.com/livetemplate/livetemplate"
 )
 
-// validateNav is the per-process validator shared by navigation-category
-// controllers. The validator package caches struct/field metadata internally,
-// so a singleton is faster than constructing one per request.
-//
-// We use BindAndValidate (not ctx.ValidateForm) for Modal Dialog because
-// ExtractFormSchema's HTML5-attribute parsing does not currently surface a
-// form schema for forms inside a <dialog>; the explicit struct + validator
-// tags is the same shape used by examples/dialog-patterns and works reliably
-// across all form-positioning cases.
+// ctx.ValidateForm doesn't surface a schema for forms inside <dialog>;
+// use BindAndValidate (the dialog-patterns shape) instead.
 var validateNav = validator.New()
 
 // --- Pattern #17: Modal Dialog ---
 
-// ModalDialogController demonstrates a native <dialog> opened via the Invoker
-// Commands API (command/commandfor). On invalid submit the form's field errors
-// must render inside the still-open dialog — that's the load-bearing behavior
-// this pattern shows; on valid submit the dialog closes and a flash appears
-// outside it.
+// On invalid submit, field errors must render inside the still-open dialog.
 type ModalDialogController struct{}
 
 type modalDialogInput struct {
@@ -63,10 +52,8 @@ func modalDialogHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #18: Confirm Dialog ---
 
-// ConfirmDialogController gates a destructive action behind a per-row
-// <dialog id="confirm-{{.ID}}">. The Delete action reads the item id from the
-// submit button's value attribute (the canonical Tier-1 row-action shape),
-// not a hidden input.
+// The Delete action reads the item id from the submit button's value attribute
+// (the canonical Tier-1 row-action shape), not a hidden input.
 type ConfirmDialogController struct{}
 
 const confirmDialogItemCount = 5
@@ -97,11 +84,8 @@ func confirmDialogHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #19: Tabs (HATEOAS) ---
 
-// TabsController is Mount-only. Tab clicks are <a href="?tab=…"> which the
-// framework routes through the WebSocket as the reserved __navigate__ action;
-// the server re-runs Mount() with the new query params and ctx.Action() is ""
-// inside that re-run, so the same `if ctx.Action() == ""` guard used on initial
-// GET also covers tab switches.
+// Mount-only: tab links use the in-band __navigate__ action, which re-runs
+// Mount with ctx.Action()=="" so the same guard covers initial GET.
 type TabsController struct{}
 
 var validTabs = map[string]bool{"overview": true, "settings": true, "activity": true}
@@ -109,9 +93,14 @@ var validTabs = map[string]bool{"overview": true, "settings": true, "activity": 
 func (c *TabsController) Mount(state TabsState, ctx *livetemplate.Context) (TabsState, error) {
 	if ctx.Action() == "" {
 		t := ctx.GetString("tab")
-		if t != "" && validTabs[t] {
+		switch {
+		case t != "" && validTabs[t]:
 			state.ActiveTab = t
-		} else if t != "" || !validTabs[state.ActiveTab] {
+		case t != "":
+			// Explicit unknown tab → reset to overview (matches template promise).
+			state.ActiveTab = "overview"
+		case !validTabs[state.ActiveTab]:
+			// First load (no param, empty state) → default to overview.
 			state.ActiveTab = "overview"
 		}
 	}
@@ -131,10 +120,6 @@ func tabsHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #20: SPA Navigation ---
 
-// SPANavController demonstrates the framework's automatic link interception:
-// same-pathname query-string changes go through the in-band __navigate__ action
-// over WebSocket, cross-pathname links trigger a full reconnect, and external
-// targets opt out with lvt-nav:no-intercept.
 type SPANavController struct{}
 
 const spaNavMaxStep = 3
@@ -166,10 +151,8 @@ func spaNavigationHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #21: Keyboard Shortcuts ---
 
-// ShortcutsController is Tier-2: it uses lvt-on:window:keydown bindings to
-// drive a command-palette-style overlay. "/" opens the panel; "Escape" closes
-// it (bound only while the panel is rendered). A bounded log of recent open/
-// close events surfaces the state in the page itself.
+// Tier-2: lvt-on:window:keydown drives the panel; "/" opens, "Escape" closes
+// (bound only while the panel is rendered).
 type ShortcutsController struct{}
 
 const shortcutsLogMax = 5

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -11,28 +11,20 @@ import (
 	"github.com/livetemplate/livetemplate"
 )
 
-// validateNav is a single per-process validator instance shared by all
-// navigation-category controllers that use BindAndValidate. The validator
-// package recommends a singleton because internal struct/field caches are
-// computed lazily on first access.
+// validateNav is the per-process validator shared by navigation-category
+// controllers. The validator package caches struct/field metadata internally,
+// so a single instance is faster than constructing one per request.
 var validateNav = validator.New()
 
 // --- Pattern #17: Modal Dialog ---
 
-// ModalDialogController demonstrates a native <dialog> element triggered via
-// the Invoker Commands API (command/commandfor). The form inside the dialog
-// uses BindAndValidate so invalid submissions surface field-scoped errors via
-// {{.lvt.ErrorTag}} that render INSIDE the still-open dialog — exercising the
-// client v0.8.33 morphdom fix that allows child updates inside open dialogs.
-//
-// On a successful save the framework's diff updates the dialog wrapper and
-// the browser closes the dialog as part of normal form-submit handling; the
-// success flash then becomes visible on the page beneath the trigger button.
+// ModalDialogController demonstrates a native <dialog> opened via the Invoker
+// Commands API (command/commandfor). On invalid submit the form's field errors
+// must render inside the still-open dialog — that's the load-bearing behavior
+// this pattern shows; on valid submit the dialog closes and a flash appears
+// outside it.
 type ModalDialogController struct{}
 
-// modalDialogInput mirrors the form fields. Validator tags drive the
-// per-field error messages that {{.lvt.ErrorTag "name"}} renders inside the
-// dialog when validation fails.
 type modalDialogInput struct {
 	Name  string `json:"name"  validate:"required,min=3"`
 	Email string `json:"email" validate:"required,email"`
@@ -65,16 +57,10 @@ func modalDialogHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #18: Confirm Dialog ---
 
-// ConfirmDialogController demonstrates a CSP-compliant confirmation flow: each
-// row owns its own <dialog id="confirm-{{.ID}}"> opened via command="show-modal"
-// commandfor="confirm-{{.ID}}". The Delete action reads the item id from the
-// submit button's value attribute, NOT a hidden input — see CLAUDE.md and the
-// patterns proposal for the rationale ("button name=delete value={{.ID}}").
-//
-// Items live on the controller (singleton, never cloned) behind a sync.Mutex,
-// so deletes persist across page reloads within a process. We don't use one
-// here because demo cardinality is small (5 items) and the user-visible
-// "Restore" button is intentionally absent — refreshing reseeds.
+// ConfirmDialogController gates a destructive action behind a per-row
+// <dialog id="confirm-{{.ID}}">. The Delete action reads the item id from the
+// submit button's value attribute (the canonical Tier-1 row-action shape),
+// not a hidden input.
 type ConfirmDialogController struct{}
 
 const confirmDialogItemCount = 5
@@ -106,12 +92,10 @@ func confirmDialogHandler(baseOpts []livetemplate.Option) http.Handler {
 // --- Pattern #19: Tabs (HATEOAS) ---
 
 // TabsController is Mount-only. Tab clicks are <a href="?tab=…"> which the
-// client routes through the WebSocket as the reserved __navigate__ action
-// (library v0.8.19+, client v0.8.26+). The server re-runs Mount() with the
-// new query params; ctx.Action() returns "" inside that re-run (the action
-// loop sets it via WithAction("")), so the same `if ctx.Action() == ""`
-// guard used on initial GET also runs on tab switches. Compare to Pattern
-// #13 (URL-Preserved Filters) which uses the same shape.
+// framework routes through the WebSocket as the reserved __navigate__ action;
+// the server re-runs Mount() with the new query params and ctx.Action() is ""
+// inside that re-run, so the same `if ctx.Action() == ""` guard used on initial
+// GET also covers tab switches.
 type TabsController struct{}
 
 var validTabs = map[string]bool{"overview": true, "settings": true, "activity": true}
@@ -141,11 +125,9 @@ func tabsHandler(baseOpts []livetemplate.Option) http.Handler {
 // --- Pattern #20: SPA Navigation ---
 
 // SPANavController demonstrates the framework's automatic link interception:
-// same-pathname query-string changes use the in-band __navigate__ action over
-// WebSocket, while cross-pathname links trigger a full reconnect. The Step
-// counter ([1, 3]) showcases the same-pathname path; cross-pathname is shown
-// via links to other pattern handlers; lvt-nav:no-intercept is shown via an
-// external link.
+// same-pathname query-string changes go through the in-band __navigate__ action
+// over WebSocket, cross-pathname links trigger a full reconnect, and external
+// targets opt out with lvt-nav:no-intercept.
 type SPANavController struct{}
 
 const spaNavMaxStep = 3
@@ -178,10 +160,9 @@ func spaNavigationHandler(baseOpts []livetemplate.Option) http.Handler {
 // --- Pattern #21: Keyboard Shortcuts ---
 
 // ShortcutsController is Tier-2: it uses lvt-on:window:keydown bindings to
-// drive a command-palette-style overlay. Open binds "/", Close binds "Escape"
-// inside the open panel. A small ring buffer of activity log entries doubles
-// as visual feedback in the rendered HTML — handy for the e2e tests since
-// the panel state can be confirmed without screen-scraping the overlay.
+// drive a command-palette-style overlay. "/" opens the panel; "Escape" closes
+// it (bound only while the panel is rendered). A bounded log of recent open/
+// close events surfaces the state in the page itself.
 type ShortcutsController struct{}
 
 const shortcutsLogMax = 5

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -66,6 +66,8 @@ func (c *ConfirmDialogController) Mount(state ConfirmDialogState, ctx *livetempl
 }
 
 func (c *ConfirmDialogController) Delete(state ConfirmDialogState, ctx *livetemplate.Context) (ConfirmDialogState, error) {
+	// "value" is the framework key for the clicked submit button's value
+	// attribute (independent of the button's name). Same idiom as dialog-patterns.
 	id := ctx.GetString("value")
 	state.Items = slices.DeleteFunc(state.Items, func(it Item) bool { return it.ID == id })
 	return state, nil
@@ -126,6 +128,7 @@ const spaNavMaxStep = 3
 
 func (c *SPANavController) Mount(state SPANavState, ctx *livetemplate.Context) (SPANavState, error) {
 	if ctx.Action() == "" {
+		// Out-of-range or non-integer step → fall through to the default below.
 		if s := ctx.GetString("step"); s != "" {
 			if n, err := strconv.Atoi(s); err == nil && n >= 1 && n <= spaNavMaxStep {
 				state.Step = n

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -69,6 +69,8 @@ func (c *ConfirmDialogController) Delete(state ConfirmDialogState, ctx *livetemp
 	// "value" is the framework key for the clicked submit button's value
 	// attribute (independent of the button's name). Same idiom as dialog-patterns.
 	id := ctx.GetString("value")
+	// Unknown ids are tolerated as a no-op — the next render reconciles any
+	// drift between client and server item lists without surfacing a flash.
 	state.Items = slices.DeleteFunc(state.Items, func(it Item) bool { return it.ID == id })
 	return state, nil
 }

--- a/patterns/handlers_navigation.go
+++ b/patterns/handlers_navigation.go
@@ -110,6 +110,11 @@ func (c *TabsController) Mount(state TabsState, ctx *livetemplate.Context) (Tabs
 			state.ActiveTab = "overview"
 		}
 	}
+	// Invariant: by here ActiveTab is always in validTabs. Belt-and-suspenders
+	// in case a malformed message routes through Mount with ctx.Action() != "".
+	if !validTabs[state.ActiveTab] {
+		state.ActiveTab = "overview"
+	}
 	return state, nil
 }
 

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -90,6 +90,13 @@ func main() {
 	mux.Handle("/patterns/loading/progress-bar", progressBarHandler(baseOpts))
 	mux.Handle("/patterns/loading/async-operations", asyncOperationsHandler(baseOpts))
 
+	// Category: Dialogs, Tabs & Navigation (#17–#21)
+	mux.Handle("/patterns/navigation/modal-dialog", modalDialogHandler(baseOpts))
+	mux.Handle("/patterns/navigation/confirm-dialog", confirmDialogHandler(baseOpts))
+	mux.Handle("/patterns/navigation/tabs", tabsHandler(baseOpts))
+	mux.Handle("/patterns/navigation/spa-navigation", spaNavigationHandler(baseOpts))
+	mux.Handle("/patterns/navigation/keyboard-shortcuts", keyboardShortcutsHandler(baseOpts))
+
 	// Client library and CSS (dev mode)
 	if localClient := os.Getenv("LVT_LOCAL_CLIENT"); localClient != "" {
 		mux.HandleFunc("/livetemplate-client.js", func(w http.ResponseWriter, r *http.Request) {

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1842,6 +1842,20 @@ func TestModalDialog(t *testing.T) {
 		if !strings.Contains(bodyText, "Grace Hopper") {
 			t.Error("Saved Name 'Grace Hopper' not visible in page text")
 		}
+		// Re-open the dialog and verify the form input now reflects the saved
+		// state (the value="{{.Name}}" template expression should have rerendered).
+		var nameValue string
+		err = chromedp.Run(ctx,
+			chromedp.Click(`button[commandfor="edit-dialog"][command="show-modal"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 5*time.Second),
+			chromedp.Value(`dialog#edit-dialog input[name="name"]`, &nameValue, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Re-open dialog to verify form state failed: %v", err)
+		}
+		if nameValue != "Grace Hopper" {
+			t.Errorf("Form input not repopulated from saved state; got %q, want %q", nameValue, "Grace Hopper")
+		}
 	})
 
 	t.Run("Open_Via_Hash_Link", func(t *testing.T) {

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2165,6 +2165,28 @@ func TestSPANavigation(t *testing.T) {
 		}
 	})
 
+	t.Run("Step_3_Direct_URL_Activates", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url+"?step=3"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			e2etest.WaitForText(`section p strong`, "Step 3 of 3", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Direct ?step=3 load failed: %v", err)
+		}
+	})
+
+	t.Run("Out_Of_Range_Step_Falls_Back_To_Default", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url+"?step=99"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			e2etest.WaitForText(`section p strong`, "Step 1 of 3", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Out-of-range ?step= did not fall back to Step 1: %v", err)
+		}
+	})
+
 	runStandardSubtests(t, ctx, false, "SPA Navigation — page heading and three sections: same-pathname step nav with Step indicator, cross-pathname links to other patterns, and an external link section.")
 }
 

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1796,17 +1796,13 @@ func TestModalDialog(t *testing.T) {
 	})
 
 	t.Run("Submit_Invalid_Form_Stays_Open_With_Field_Errors", func(t *testing.T) {
-		// Disable HTML5 validation so the empty input reaches the server,
-		// where the validator's `required,min=3` tag emits a field-level
-		// error. The error renders inside the still-open dialog — this is
-		// the v0.8.33 morphdom child-update fix in action.
+		// noValidate=true bypasses HTML5 form validation so the empty input
+		// reaches the server's validator, which is what we want to exercise.
 		err := chromedp.Run(ctx,
-			// Make sure the dialog is open from the previous subtest.
 			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 3*time.Second),
 			chromedp.Evaluate(`document.querySelector('dialog#edit-dialog form').noValidate = true`, nil),
 			chromedp.Clear(`dialog#edit-dialog input[name="name"]`, chromedp.ByQuery),
 			chromedp.Click(`dialog#edit-dialog button[type="submit"]`, chromedp.ByQuery),
-			// The error tag is rendered with a <small> wrapper by ErrorTag.
 			e2etest.WaitFor(`(() => { const d = document.getElementById('edit-dialog'); return d.open && d.querySelector('input[name="name"][aria-invalid="true"]') !== null; })()`, 5*time.Second),
 		)
 		if err != nil {
@@ -1817,7 +1813,7 @@ func TestModalDialog(t *testing.T) {
 			t.Fatalf("Read dialog state failed: %v", err)
 		}
 		if !dialogOpen {
-			t.Error("Dialog should remain open after invalid submit (v0.8.33 fix)")
+			t.Error("Dialog should remain open after invalid submit")
 		}
 		var errorText string
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`(() => { const s = document.querySelector('dialog#edit-dialog small'); return s ? s.textContent.trim() : ""; })()`, &errorText)); err != nil {
@@ -1830,15 +1826,9 @@ func TestModalDialog(t *testing.T) {
 
 	t.Run("Submit_Valid_Form_Closes_Dialog_And_Updates_State", func(t *testing.T) {
 		err := chromedp.Run(ctx,
-			// Re-open the dialog (previous subtest left it open) and fill in
-			// a valid Name + Email. We rely on the seed Email being still
-			// valid; just type a fresh Name.
 			chromedp.Clear(`dialog#edit-dialog input[name="name"]`, chromedp.ByQuery),
 			chromedp.SendKeys(`dialog#edit-dialog input[name="name"]`, "Grace Hopper", chromedp.ByQuery),
 			chromedp.Click(`dialog#edit-dialog button[type="submit"]`, chromedp.ByQuery),
-			// Either: the dialog closes (matches dialog-patterns behavior) AND
-			// flash text appears beneath the trigger button. We assert flash
-			// presence first since that's the user-visible success signal.
 			e2etest.WaitForText(`output[data-flash="success"]`, "Profile saved", 5*time.Second),
 		)
 		if err != nil {
@@ -1875,9 +1865,6 @@ func TestModalDialog(t *testing.T) {
 	})
 
 	t.Run("Browser_Back_Closes_Dialog", func(t *testing.T) {
-		// Continuing from the previous subtest's state: dialog open, hash set.
-		// History.back() should pop to the prior state with no #edit-dialog,
-		// at which point hash-link.ts:handlePopstate sweeps the open dialog.
 		err := chromedp.Run(ctx,
 			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 3*time.Second),
 			chromedp.Evaluate(`history.back()`, nil),
@@ -1966,7 +1953,6 @@ func TestConfirmDialog(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Delete via confirm failed: %v", err)
 		}
-		// The deleted row's data-key must be gone from the DOM.
 		var hasDeleted bool
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('tr[data-key="3"]')`, &hasDeleted)); err != nil {
 			t.Fatalf("Deleted row check failed: %v", err)
@@ -1977,9 +1963,7 @@ func TestConfirmDialog(t *testing.T) {
 	})
 
 	t.Run("Per_Item_Hash_Link_Opens_Specific_Dialog", func(t *testing.T) {
-		// A direct navigation with a hash fragment must auto-activate the
-		// matching dialog (client v0.8.30+ hash-link). Use confirm-1 since
-		// confirm-3 was just deleted in the previous subtest.
+		// confirm-3 was just deleted, so use confirm-1.
 		err := chromedp.Run(ctx,
 			chromedp.Navigate(url+"#confirm-1"),
 			e2etest.WaitForWebSocketReady(5*time.Second),
@@ -2036,10 +2020,8 @@ func TestTabs(t *testing.T) {
 	})
 
 	t.Run("Tab_Switch_Uses_WebSocket_Not_HTTP", func(t *testing.T) {
-		// Listen for any HTTP request to the tabs URL while clicking
-		// Activity. The __navigate__ fast path must not trigger a fetch().
-		// We stash hits from a fetch override on window so we can read it
-		// after the click. The override is removed after the assertion.
+		// Override window.fetch to count HTTP requests to the tabs URL.
+		// The __navigate__ in-band path must not trigger any.
 		err := chromedp.Run(ctx,
 			chromedp.Evaluate(`(() => {
 				window.__navHttpHits = 0;
@@ -2191,10 +2173,8 @@ func TestKeyboardShortcuts(t *testing.T) {
 	})
 
 	t.Run("Slash_Key_Opens_Panel", func(t *testing.T) {
-		// Dispatching a synthetic KeyboardEvent at the window is the
-		// standard headless-Chrome workaround when chromedp.KeyEvent
-		// would deliver to the focused element rather than window
-		// (where lvt-on:window:keydown listens).
+		// chromedp.KeyEvent delivers to the focused element; lvt-on:window:keydown
+		// listens at the window, so we dispatch a synthetic event there.
 		err := chromedp.Run(ctx,
 			chromedp.Evaluate(`window.dispatchEvent(new KeyboardEvent('keydown', {key: '/', bubbles: true}))`, nil),
 			e2etest.WaitForText(`h4`, "Command Panel", 5*time.Second),

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1830,9 +1830,10 @@ func TestModalDialog(t *testing.T) {
 			chromedp.SendKeys(`dialog#edit-dialog input[name="name"]`, "Grace Hopper", chromedp.ByQuery),
 			chromedp.Click(`dialog#edit-dialog button[type="submit"]`, chromedp.ByQuery),
 			e2etest.WaitForText(`output[data-flash="success"]`, "Profile saved", 5*time.Second),
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === false`, 5*time.Second),
 		)
 		if err != nil {
-			t.Fatalf("Valid form submit did not produce success flash: %v", err)
+			t.Fatalf("Valid form submit did not produce success flash + dialog close: %v", err)
 		}
 		var bodyText string
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.body.textContent`, &bodyText)); err != nil {
@@ -2021,7 +2022,12 @@ func TestTabs(t *testing.T) {
 
 	t.Run("Tab_Switch_Uses_WebSocket_Not_HTTP", func(t *testing.T) {
 		// Override window.fetch to count HTTP requests to the tabs URL.
-		// The __navigate__ in-band path must not trigger any.
+		// The __navigate__ in-band path must not trigger any. t.Cleanup
+		// guarantees the restore even if a chromedp step fails mid-flow,
+		// so a failure here cannot pollute later subtests.
+		t.Cleanup(func() {
+			_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { if (window.__origFetch) { window.fetch = window.__origFetch; delete window.__origFetch; } })()`, nil))
+		})
 		err := chromedp.Run(ctx,
 			chromedp.Evaluate(`(() => {
 				window.__navHttpHits = 0;
@@ -2045,8 +2051,6 @@ func TestTabs(t *testing.T) {
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__navHttpHits`, &hits)); err != nil {
 			t.Fatalf("HTTP hit count read failed: %v", err)
 		}
-		// Restore fetch.
-		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origFetch; })()`, nil))
 		if hits != 0 {
 			t.Errorf("Same-pathname tab switch should use WebSocket __navigate__, not HTTP fetch (got %d HTTP hits)", hits)
 		}
@@ -2104,6 +2108,9 @@ func TestSPANavigation(t *testing.T) {
 	})
 
 	t.Run("Same_Pathname_Step_Update_No_HTTP", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { if (window.__origFetch2) { window.fetch = window.__origFetch2; delete window.__origFetch2; } })()`, nil))
+		})
 		err := chromedp.Run(ctx,
 			chromedp.Evaluate(`(() => {
 				window.__spaHttpHits = 0;
@@ -2126,7 +2133,6 @@ func TestSPANavigation(t *testing.T) {
 		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__spaHttpHits`, &hits)); err != nil {
 			t.Fatalf("HTTP hit count read failed: %v", err)
 		}
-		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origFetch2; })()`, nil))
 		if hits != 0 {
 			t.Errorf("Same-pathname step update should use WebSocket __navigate__, got %d HTTP hits", hits)
 		}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1753,3 +1753,496 @@ func TestAsyncOperations(t *testing.T) {
 
 	runStandardSubtests(t, ctx, false, "Async Operations — 'Fetch Data' button followed by either a success flash and blockquote with fetch result, or an error flash and mark element with an error message")
 }
+
+// --- Pattern #17: Modal Dialog ---
+
+func TestModalDialog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/navigation/modal-dialog"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[commandfor="edit-dialog"][command="show-modal"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+		var dialogOpen bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.getElementById('edit-dialog').open`, &dialogOpen)); err != nil {
+			t.Fatalf("Read dialog state failed: %v", err)
+		}
+		if dialogOpen {
+			t.Error("Dialog should be closed on initial load")
+		}
+	})
+
+	t.Run("Open_Via_Button", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[commandfor="edit-dialog"][command="show-modal"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Open via button failed: %v", err)
+		}
+	})
+
+	t.Run("Submit_Invalid_Form_Stays_Open_With_Field_Errors", func(t *testing.T) {
+		// Disable HTML5 validation so the empty input reaches the server,
+		// where the validator's `required,min=3` tag emits a field-level
+		// error. The error renders inside the still-open dialog — this is
+		// the v0.8.33 morphdom child-update fix in action.
+		err := chromedp.Run(ctx,
+			// Make sure the dialog is open from the previous subtest.
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 3*time.Second),
+			chromedp.Evaluate(`document.querySelector('dialog#edit-dialog form').noValidate = true`, nil),
+			chromedp.Clear(`dialog#edit-dialog input[name="name"]`, chromedp.ByQuery),
+			chromedp.Click(`dialog#edit-dialog button[type="submit"]`, chromedp.ByQuery),
+			// The error tag is rendered with a <small> wrapper by ErrorTag.
+			e2etest.WaitFor(`(() => { const d = document.getElementById('edit-dialog'); return d.open && d.querySelector('input[name="name"][aria-invalid="true"]') !== null; })()`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Invalid form submit did not produce field error inside open dialog: %v", err)
+		}
+		var dialogOpen bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.getElementById('edit-dialog').open`, &dialogOpen)); err != nil {
+			t.Fatalf("Read dialog state failed: %v", err)
+		}
+		if !dialogOpen {
+			t.Error("Dialog should remain open after invalid submit (v0.8.33 fix)")
+		}
+		var errorText string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`(() => { const s = document.querySelector('dialog#edit-dialog small'); return s ? s.textContent.trim() : ""; })()`, &errorText)); err != nil {
+			t.Fatalf("Read error text failed: %v", err)
+		}
+		if errorText == "" {
+			t.Error("Expected a field error message inside the dialog, found none")
+		}
+	})
+
+	t.Run("Submit_Valid_Form_Closes_Dialog_And_Updates_State", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			// Re-open the dialog (previous subtest left it open) and fill in
+			// a valid Name + Email. We rely on the seed Email being still
+			// valid; just type a fresh Name.
+			chromedp.Clear(`dialog#edit-dialog input[name="name"]`, chromedp.ByQuery),
+			chromedp.SendKeys(`dialog#edit-dialog input[name="name"]`, "Grace Hopper", chromedp.ByQuery),
+			chromedp.Click(`dialog#edit-dialog button[type="submit"]`, chromedp.ByQuery),
+			// Either: the dialog closes (matches dialog-patterns behavior) AND
+			// flash text appears beneath the trigger button. We assert flash
+			// presence first since that's the user-visible success signal.
+			e2etest.WaitForText(`output[data-flash="success"]`, "Profile saved", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Valid form submit did not produce success flash: %v", err)
+		}
+		var bodyText string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.body.textContent`, &bodyText)); err != nil {
+			t.Fatalf("Read body text failed: %v", err)
+		}
+		if !strings.Contains(bodyText, "Grace Hopper") {
+			t.Error("Saved Name 'Grace Hopper' not visible in page text")
+		}
+	})
+
+	t.Run("Open_Via_Hash_Link", func(t *testing.T) {
+		// Reset to a clean URL first (no #hash), then click the hash anchor.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="#edit-dialog"]`, chromedp.ByQuery),
+			chromedp.Click(`a[href="#edit-dialog"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Open via hash link failed: %v", err)
+		}
+		var hash string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`location.hash`, &hash)); err != nil {
+			t.Fatalf("Read hash failed: %v", err)
+		}
+		if hash != "#edit-dialog" {
+			t.Errorf("Expected #edit-dialog after hash-link click, got %q", hash)
+		}
+	})
+
+	t.Run("Browser_Back_Closes_Dialog", func(t *testing.T) {
+		// Continuing from the previous subtest's state: dialog open, hash set.
+		// History.back() should pop to the prior state with no #edit-dialog,
+		// at which point hash-link.ts:handlePopstate sweeps the open dialog.
+		err := chromedp.Run(ctx,
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === true`, 3*time.Second),
+			chromedp.Evaluate(`history.back()`, nil),
+			e2etest.WaitFor(`document.getElementById('edit-dialog').open === false`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Browser Back did not close the dialog: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Modal Dialog — page heading, profile summary, an 'Edit profile' button, and an 'Open via URL hash' secondary link. The dialog itself is closed at this point.")
+}
+
+// --- Pattern #18: Confirm Dialog ---
+
+func TestConfirmDialog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/navigation/confirm-dialog"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[commandfor="confirm-1"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+		var rowCount int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.querySelectorAll('tbody tr[data-key]').length`, &rowCount)); err != nil {
+			t.Fatalf("Row count read failed: %v", err)
+		}
+		if rowCount != confirmDialogItemCount {
+			t.Errorf("Expected %d rows, got %d", confirmDialogItemCount, rowCount)
+		}
+	})
+
+	t.Run("Open_Specific_Item_Confirm", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[commandfor="confirm-2"][command="show-modal"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('confirm-2').open === true`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Open confirm-2 failed: %v", err)
+		}
+		var otherOpen bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.getElementById('confirm-1').open || document.getElementById('confirm-3').open`, &otherOpen)); err != nil {
+			t.Fatalf("Sibling dialog state read failed: %v", err)
+		}
+		if otherOpen {
+			t.Error("Sibling confirm dialogs should remain closed")
+		}
+	})
+
+	t.Run("Cancel_Closes_Without_Deleting", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`dialog#confirm-2 button[command="close"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('confirm-2').open === false`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Cancel close failed: %v", err)
+		}
+		var rowCount int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`document.querySelectorAll('tbody tr[data-key]').length`, &rowCount)); err != nil {
+			t.Fatalf("Row count read failed: %v", err)
+		}
+		if rowCount != confirmDialogItemCount {
+			t.Errorf("Expected %d rows after cancel, got %d", confirmDialogItemCount, rowCount)
+		}
+	})
+
+	t.Run("Confirm_Deletes_Item", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[commandfor="confirm-3"][command="show-modal"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.getElementById('confirm-3').open === true`, 5*time.Second),
+			chromedp.Click(`dialog#confirm-3 button[name="delete"]`, chromedp.ByQuery),
+			e2etest.WaitForCount(`tbody tr[data-key]`, confirmDialogItemCount-1, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Delete via confirm failed: %v", err)
+		}
+		// The deleted row's data-key must be gone from the DOM.
+		var hasDeleted bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('tr[data-key="3"]')`, &hasDeleted)); err != nil {
+			t.Fatalf("Deleted row check failed: %v", err)
+		}
+		if hasDeleted {
+			t.Error("Row with data-key=3 should be removed after delete")
+		}
+	})
+
+	t.Run("Per_Item_Hash_Link_Opens_Specific_Dialog", func(t *testing.T) {
+		// A direct navigation with a hash fragment must auto-activate the
+		// matching dialog (client v0.8.30+ hash-link). Use confirm-1 since
+		// confirm-3 was just deleted in the previous subtest.
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url+"#confirm-1"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			e2etest.WaitFor(`document.getElementById('confirm-1') && document.getElementById('confirm-1').open === true`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Direct hash-link did not open confirm-1: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Confirm Dialog — page heading, table of items each with a Delete button, and one open dialog showing 'Delete \"<name>\"?' confirmation prompt with Cancel and Delete buttons.")
+}
+
+// --- Pattern #19: Tabs (HATEOAS) ---
+
+func TestTabs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/navigation/tabs"
+
+	t.Run("Default_Tab_Is_Overview", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="?tab=overview"][aria-current="page"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Default tab not Overview: %v", err)
+		}
+	})
+
+	t.Run("Click_Settings_Tab_Activates_It", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`a[href="?tab=settings"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('a[href="?tab=settings"][aria-current="page"]')`, 5*time.Second),
+			e2etest.WaitForText(`section h4`, "Settings", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Settings tab click failed: %v", err)
+		}
+		var overviewActive bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('a[href="?tab=overview"][aria-current="page"]')`, &overviewActive)); err != nil {
+			t.Fatalf("Overview state read failed: %v", err)
+		}
+		if overviewActive {
+			t.Error("Overview tab should no longer be active after Settings click")
+		}
+	})
+
+	t.Run("Tab_Switch_Uses_WebSocket_Not_HTTP", func(t *testing.T) {
+		// Listen for any HTTP request to the tabs URL while clicking
+		// Activity. The __navigate__ fast path must not trigger a fetch().
+		// We stash hits from a fetch override on window so we can read it
+		// after the click. The override is removed after the assertion.
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`(() => {
+				window.__navHttpHits = 0;
+				window.__origFetch = window.fetch;
+				window.fetch = function(input, init) {
+					try {
+						const u = typeof input === 'string' ? input : input.url;
+						if (u && u.includes('/patterns/navigation/tabs')) window.__navHttpHits++;
+					} catch (e) {}
+					return window.__origFetch.apply(window, arguments);
+				};
+			})()`, nil),
+			chromedp.Click(`a[href="?tab=activity"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('a[href="?tab=activity"][aria-current="page"]')`, 5*time.Second),
+			e2etest.WaitForText(`section h4`, "Activity", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Activity tab click failed: %v", err)
+		}
+		var hits int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__navHttpHits`, &hits)); err != nil {
+			t.Fatalf("HTTP hit count read failed: %v", err)
+		}
+		// Restore fetch.
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origFetch; })()`, nil))
+		if hits != 0 {
+			t.Errorf("Same-pathname tab switch should use WebSocket __navigate__, not HTTP fetch (got %d HTTP hits)", hits)
+		}
+	})
+
+	t.Run("Direct_URL_Load_Activates_Tab", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url+"?tab=settings"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="?tab=settings"][aria-current="page"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`section h4`, "Settings", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Direct URL load with ?tab=settings failed: %v", err)
+		}
+	})
+
+	t.Run("Invalid_Tab_Falls_Back_To_Default", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url+"?tab=garbage"),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="?tab=overview"][aria-current="page"]`, chromedp.ByQuery),
+		)
+		if err != nil {
+			t.Fatalf("Invalid tab fallback failed: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Tabs (HATEOAS) — page heading, three-tab nav with the Overview tab marked active, and an Overview content section beneath.")
+}
+
+// --- Pattern #20: SPA Navigation ---
+
+func TestSPANavigation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/navigation/spa-navigation"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`a[href="?step=1"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			e2etest.WaitForText(`section p strong`, "Step 1 of 3", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Same_Pathname_Step_Update_No_HTTP", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`(() => {
+				window.__spaHttpHits = 0;
+				window.__origFetch2 = window.fetch;
+				window.fetch = function(input, init) {
+					try {
+						const u = typeof input === 'string' ? input : input.url;
+						if (u && u.includes('/patterns/navigation/spa-navigation')) window.__spaHttpHits++;
+					} catch (e) {}
+					return window.__origFetch2.apply(window, arguments);
+				};
+			})()`, nil),
+			chromedp.Click(`a[href="?step=2"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`section p strong`, "Step 2 of 3", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Step-2 click failed: %v", err)
+		}
+		var hits int
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__spaHttpHits`, &hits)); err != nil {
+			t.Fatalf("HTTP hit count read failed: %v", err)
+		}
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { window.fetch = window.__origFetch2; })()`, nil))
+		if hits != 0 {
+			t.Errorf("Same-pathname step update should use WebSocket __navigate__, got %d HTTP hits", hits)
+		}
+	})
+
+	t.Run("External_Link_Has_No_Intercept_Attribute", func(t *testing.T) {
+		var hasAttr bool
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`!!document.querySelector('a[href="https://example.com"][lvt-nav\\:no-intercept]')`, &hasAttr),
+		)
+		if err != nil {
+			t.Fatalf("External link attribute check failed: %v", err)
+		}
+		if !hasAttr {
+			t.Error("External example.com link must carry lvt-nav:no-intercept opt-out attribute")
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "SPA Navigation — page heading and three sections: same-pathname step nav with Step indicator, cross-pathname links to other patterns, and an external link section.")
+}
+
+// --- Pattern #21: Keyboard Shortcuts ---
+
+func TestKeyboardShortcuts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/navigation/keyboard-shortcuts"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="open"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Slash_Key_Opens_Panel", func(t *testing.T) {
+		// Dispatching a synthetic KeyboardEvent at the window is the
+		// standard headless-Chrome workaround when chromedp.KeyEvent
+		// would deliver to the focused element rather than window
+		// (where lvt-on:window:keydown listens).
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`window.dispatchEvent(new KeyboardEvent('keydown', {key: '/', bubbles: true}))`, nil),
+			e2etest.WaitForText(`h4`, "Command Panel", 5*time.Second),
+			e2etest.WaitFor(`(() => {
+				const items = document.querySelectorAll('ul li small');
+				return Array.from(items).some(el => (el.textContent || "").includes("Opened panel"));
+			})()`, 3*time.Second),
+		)
+		if err != nil {
+			var html string
+			_ = chromedp.Run(ctx, chromedp.OuterHTML(`body`, &html, chromedp.ByQuery))
+			t.Fatalf("Slash key did not open panel: %v\nrendered body:\n%s", err, html)
+		}
+	})
+
+	t.Run("Escape_Closes_Panel", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`window.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape', bubbles: true}))`, nil),
+			e2etest.WaitForText(`button`, "Open panel", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Escape did not close panel: %v", err)
+		}
+		var logHasClose bool
+		// `ul li small` matches the layout's category breadcrumb too, so
+		// scan all matches for the "Closed panel" entry rather than relying
+		// on the first match.
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`Array.from(document.querySelectorAll('ul li small')).some(el => (el.textContent || "").includes('Closed panel'))`, &logHasClose)); err != nil {
+			t.Fatalf("Log read failed: %v", err)
+		}
+		if !logHasClose {
+			t.Error("Activity log should contain a 'Closed panel' entry")
+		}
+	})
+
+	t.Run("Tier1_Form_Fallback_Works", func(t *testing.T) {
+		// Re-open via /, then close via the in-panel form button (which
+		// works without keyboard or JS as a Tier-1 fallback).
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`window.dispatchEvent(new KeyboardEvent('keydown', {key: '/', bubbles: true}))`, nil),
+			e2etest.WaitForText(`h4`, "Command Panel", 5*time.Second),
+			chromedp.Click(`button[name="close"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`button`, "Open panel", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Tier-1 form fallback close failed: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Keyboard Shortcuts — page heading with shortcut hints (kbd elements for / and Escape), an 'Open panel' button when closed, and an Activity log with recent open/close entries.")
+}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1954,11 +1954,11 @@ func TestConfirmDialog(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Delete via confirm failed: %v", err)
 		}
-		var hasDeleted bool
-		if err := chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('tr[data-key="3"]')`, &hasDeleted)); err != nil {
-			t.Fatalf("Deleted row check failed: %v", err)
+		var rowExists bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('tr[data-key="3"]')`, &rowExists)); err != nil {
+			t.Fatalf("Row existence check failed: %v", err)
 		}
-		if hasDeleted {
+		if rowExists {
 			t.Error("Row with data-key=3 should be removed after delete")
 		}
 	})
@@ -2109,18 +2109,18 @@ func TestSPANavigation(t *testing.T) {
 
 	t.Run("Same_Pathname_Step_Update_No_HTTP", func(t *testing.T) {
 		t.Cleanup(func() {
-			_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { if (window.__origFetch2) { window.fetch = window.__origFetch2; delete window.__origFetch2; } })()`, nil))
+			_ = chromedp.Run(ctx, chromedp.Evaluate(`(() => { if (window.__origFetchSPA) { window.fetch = window.__origFetchSPA; delete window.__origFetchSPA; } })()`, nil))
 		})
 		err := chromedp.Run(ctx,
 			chromedp.Evaluate(`(() => {
 				window.__spaHttpHits = 0;
-				window.__origFetch2 = window.fetch;
+				window.__origFetchSPA = window.fetch;
 				window.fetch = function(input, init) {
 					try {
 						const u = typeof input === 'string' ? input : input.url;
 						if (u && u.includes('/patterns/navigation/spa-navigation')) window.__spaHttpHits++;
 					} catch (e) {}
-					return window.__origFetch2.apply(window, arguments);
+					return window.__origFetchSPA.apply(window, arguments);
 				};
 			})()`, nil),
 			chromedp.Click(`a[href="?step=2"]`, chromedp.ByQuery),
@@ -2175,6 +2175,18 @@ func TestKeyboardShortcuts(t *testing.T) {
 		)
 		if err != nil {
 			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Open_Button_Click_Opens_Panel", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="open"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`h4`, "Command Panel", 5*time.Second),
+			chromedp.Click(`button[name="close"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`button`, "Open panel", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Open-button Tier-1 fallback failed: %v", err)
 		}
 	})
 

--- a/patterns/state_navigation.go
+++ b/patterns/state_navigation.go
@@ -1,6 +1,5 @@
 package main
 
-// ModalDialogState holds the state for the Modal Dialog pattern (#17).
 type ModalDialogState struct {
 	Title    string
 	Category string
@@ -9,31 +8,24 @@ type ModalDialogState struct {
 	SavedAt  string
 }
 
-// ConfirmDialogState holds the state for the Confirm Dialog pattern (#18).
 type ConfirmDialogState struct {
 	Title    string
 	Category string
 	Items    []Item
 }
 
-// TabsState holds the state for the Tabs pattern (#19).
-// ActiveTab is one of: "overview", "settings", "activity".
 type TabsState struct {
 	Title     string
 	Category  string
 	ActiveTab string
 }
 
-// SPANavState holds the state for the SPA Navigation pattern (#20).
-// Step is clamped to [1, 3] from the ?step= query parameter.
 type SPANavState struct {
 	Title    string
 	Category string
 	Step     int
 }
 
-// ShortcutsState holds the state for the Keyboard Shortcuts pattern (#21).
-// Log retains the last shortcutsLogMax entries (FIFO).
 type ShortcutsState struct {
 	Title     string
 	Category  string

--- a/patterns/state_navigation.go
+++ b/patterns/state_navigation.go
@@ -1,0 +1,42 @@
+package main
+
+// ModalDialogState holds the state for the Modal Dialog pattern (#17).
+type ModalDialogState struct {
+	Title    string
+	Category string
+	Name     string
+	Email    string
+	SavedAt  string
+}
+
+// ConfirmDialogState holds the state for the Confirm Dialog pattern (#18).
+type ConfirmDialogState struct {
+	Title    string
+	Category string
+	Items    []Item
+}
+
+// TabsState holds the state for the Tabs pattern (#19).
+// ActiveTab is one of: "overview", "settings", "activity".
+type TabsState struct {
+	Title     string
+	Category  string
+	ActiveTab string
+}
+
+// SPANavState holds the state for the SPA Navigation pattern (#20).
+// Step is clamped to [1, 3] from the ?step= query parameter.
+type SPANavState struct {
+	Title    string
+	Category string
+	Step     int
+}
+
+// ShortcutsState holds the state for the Keyboard Shortcuts pattern (#21).
+// Log retains the last shortcutsLogMax entries (FIFO).
+type ShortcutsState struct {
+	Title     string
+	Category  string
+	PanelOpen bool
+	Log       []string
+}

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -33,7 +33,7 @@
                 <h4>Delete &ldquo;{{.Name}}&rdquo;?</h4>
             </header>
             <p>This cannot be undone.</p>
-            <form name="delete">
+            <form method="POST" name="delete">
                 <footer>
                     <fieldset role="group">
                         <button type="button" command="close" commandfor="confirm-{{.ID}}" class="secondary">Cancel</button>

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -45,7 +45,7 @@
     </dialog>
     {{end}}
     {{else}}
-    <p><small>All items deleted. Reload the page or navigate away and back to reseed the list.</small></p>
+    <p><small>All items deleted. The list reseeds on any fresh Mount — reload the page, navigate away and back, or wait for the WebSocket to reconnect.</small></p>
     {{end}}
 </article>
 {{end}}

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -25,6 +25,7 @@
         </tbody>
     </table>
 
+    {{/* Dialogs render outside the table — <dialog> inside <tbody> is invalid HTML. */}}
     {{range .Items}}
     <dialog id="confirm-{{.ID}}">
         <article>
@@ -32,7 +33,7 @@
                 <h4>Delete &ldquo;{{.Name}}&rdquo;?</h4>
             </header>
             <p>This cannot be undone.</p>
-            <form name="confirmDelete">
+            <form name="delete">
                 <footer>
                     <fieldset role="group">
                         <button type="button" command="close" commandfor="confirm-{{.ID}}" class="secondary">Cancel</button>

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -44,7 +44,7 @@
     </dialog>
     {{end}}
     {{else}}
-    <p><small>All items deleted. Refresh to reseed the list.</small></p>
+    <p><small>All items deleted. Reload the page or navigate away and back to reseed the list.</small></p>
     {{end}}
 </article>
 {{end}}

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -1,0 +1,50 @@
+{{define "content"}}
+<article>
+    <h3>Confirm Dialog</h3>
+    <p><small>Per-item confirmation gated by a native <code>&lt;dialog&gt;</code> with no inline JS. Each row owns its own dialog id (<code>confirm-{{`{{.ID}}`}}</code>) so URL hashes can deep-link to a specific row's confirmation.</small></p>
+
+    {{if .Items}}
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Items}}
+            <tr data-key="{{.ID}}">
+                <td>{{.Name}}</td>
+                <td><small>{{.Email}}</small></td>
+                <td>
+                    <button command="show-modal" commandfor="confirm-{{.ID}}" class="compact secondary outline">Delete</button>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+
+    {{range .Items}}
+    <dialog id="confirm-{{.ID}}">
+        <article>
+            <header>
+                <h4>Delete &ldquo;{{.Name}}&rdquo;?</h4>
+            </header>
+            <p>This cannot be undone.</p>
+            <form name="confirmDelete">
+                <footer>
+                    <fieldset role="group">
+                        <button type="button" command="close" commandfor="confirm-{{.ID}}" class="secondary">Cancel</button>
+                        <button name="delete" value="{{.ID}}" class="contrast">Delete</button>
+                    </fieldset>
+                </footer>
+            </form>
+        </article>
+    </dialog>
+    {{end}}
+    {{else}}
+    <p><small>All items deleted. Refresh to reseed the list.</small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/navigation/confirm-dialog.tmpl
+++ b/patterns/templates/navigation/confirm-dialog.tmpl
@@ -45,7 +45,7 @@
     </dialog>
     {{end}}
     {{else}}
-    <p><small>All items deleted. The list reseeds on any fresh Mount — reload the page, navigate away and back, or wait for the WebSocket to reconnect.</small></p>
+    <p><small>All items deleted. Reload the page or navigate away and back to reseed the list.</small></p>
     {{end}}
 </article>
 {{end}}

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -10,13 +10,13 @@
         </header>
         {{/* Decorative — wiring the search to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. */}}
         <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
-        <form name="closePanel">
+        <form method="POST" name="closePanel">
             <button name="close" class="secondary">Close</button>
         </form>
     </article>
     {{else}}
     <p><small>Panel is closed. Press <kbd>/</kbd> or click the button to open.</small></p>
-    <form name="openPanel">
+    <form method="POST" name="openPanel">
         <button name="open">Open panel</button>
     </form>
     {{end}}

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -1,0 +1,32 @@
+{{define "content"}}
+<article lvt-on:window:keydown="open" lvt-key="/">
+    <h3>Keyboard Shortcuts</h3>
+    <p><small>Press <kbd>/</kbd> to open the command panel and <kbd>Escape</kbd> to close it. Bindings use <code>lvt-on:window:keydown</code> with the <code>lvt-key</code> filter; both global and Tier-1 form fallbacks work.</small></p>
+
+    {{if .PanelOpen}}
+    <article lvt-on:window:keydown="close" lvt-key="Escape" aria-label="Command panel">
+        <header>
+            <h4>Command Panel</h4>
+        </header>
+        <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
+        <form name="closePanel">
+            <button name="close" class="secondary">Close</button>
+        </form>
+    </article>
+    {{else}}
+    <p><small>Panel is closed. Press <kbd>/</kbd> or click the button to open.</small></p>
+    <form name="openPanel">
+        <button name="open">Open panel</button>
+    </form>
+    {{end}}
+
+    <h4>Activity</h4>
+    {{if .Log}}
+    <ul>
+        {{range .Log}}<li><small>{{.}}</small></li>{{end}}
+    </ul>
+    {{else}}
+    <p><small>No activity yet.</small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -8,6 +8,7 @@
         <header>
             <h4>Command Panel</h4>
         </header>
+        {{/* Decorative — wiring the search to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. */}}
         <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
         <form name="closePanel">
             <button name="close" class="secondary">Close</button>

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -8,8 +8,8 @@
         <header>
             <h4>Command Panel</h4>
         </header>
-        {{/* Decorative — wiring to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. autofocus may also intercept the first Escape keypress in some browsers (search input clears its value before bubbling); for production use, defer focus to a wrapper or drop autofocus. */}}
-        <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
+        {{/* Decorative — wiring to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. autofocus is intentionally omitted: <input type="search"> intercepts the first Escape (clearing its value) before the window-level keydown listener sees it. */}}
+        <input type="search" placeholder="Type a command…" aria-label="Command search">
         <form method="POST" name="close">
             <button name="close" class="secondary">Close</button>
         </form>

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -10,13 +10,13 @@
         </header>
         {{/* Decorative — wiring the search to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. */}}
         <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
-        <form method="POST" name="closePanel">
+        <form method="POST" name="close">
             <button name="close" class="secondary">Close</button>
         </form>
     </article>
     {{else}}
     <p><small>Panel is closed. Press <kbd>/</kbd> or click the button to open.</small></p>
-    <form method="POST" name="openPanel">
+    <form method="POST" name="open">
         <button name="open">Open panel</button>
     </form>
     {{end}}

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -8,7 +8,7 @@
         <header>
             <h4>Command Panel</h4>
         </header>
-        {{/* Decorative — wiring the search to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. */}}
+        {{/* Decorative — wiring to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. autofocus may also intercept the first Escape keypress in some browsers (search input clears its value before bubbling); for production use, defer focus to a wrapper or drop autofocus. */}}
         <input type="search" placeholder="Type a command…" autofocus aria-label="Command search">
         <form method="POST" name="close">
             <button name="close" class="secondary">Close</button>

--- a/patterns/templates/navigation/keyboard-shortcuts.tmpl
+++ b/patterns/templates/navigation/keyboard-shortcuts.tmpl
@@ -1,15 +1,20 @@
 {{define "content"}}
+{{/* Bind the "/" listener only when the panel is closed and the "Escape" listener only when it is open — keeps stray keypresses from triggering no-op WebSocket round-trips. */}}
+{{if .PanelOpen}}
+<article lvt-on:window:keydown="close" lvt-key="Escape">
+{{else}}
 <article lvt-on:window:keydown="open" lvt-key="/">
+{{end}}
     <h3>Keyboard Shortcuts</h3>
     <p><small>Press <kbd>/</kbd> to open the command panel and <kbd>Escape</kbd> to close it. Bindings use <code>lvt-on:window:keydown</code> with the <code>lvt-key</code> filter; both global and Tier-1 form fallbacks work.</small></p>
 
     {{if .PanelOpen}}
-    <article lvt-on:window:keydown="close" lvt-key="Escape" aria-label="Command panel">
+    <article aria-label="Command panel">
         <header>
             <h4>Command Panel</h4>
         </header>
-        {{/* Decorative — wiring to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. autofocus is intentionally omitted: <input type="search"> intercepts the first Escape (clearing its value) before the window-level keydown listener sees it. */}}
-        <input type="search" placeholder="Type a command…" aria-label="Command search">
+        {{/* Decorative — wiring to a Change()/Submit() handler is out of scope for the keyboard-shortcut demo. disabled removes the false affordance of a working search box. */}}
+        <input type="search" placeholder="Type a command…" disabled aria-label="Command search">
         <form method="POST" name="close">
             <button name="close" class="secondary">Close</button>
         </form>

--- a/patterns/templates/navigation/modal-dialog.tmpl
+++ b/patterns/templates/navigation/modal-dialog.tmpl
@@ -1,0 +1,44 @@
+{{define "content"}}
+<article>
+    <h3>Modal Dialog</h3>
+    <p><small>Native <code>&lt;dialog&gt;</code> opened via the Invoker Commands API (<code>command="show-modal"</code> + <code>commandfor</code>) or directly via a hash link (<code>&lt;a href="#edit-dialog"&gt;</code>, client v0.8.30+). Submitting the form with valid input closes the dialog and shows a success flash; invalid input keeps it open with field errors rendered inside (client v0.8.33+).</small></p>
+
+    <dl>
+        <dt><strong>Profile</strong></dt>
+        <dd>{{.Name}} &middot; <small>{{.Email}}</small>{{if .SavedAt}} &middot; <small>Saved at {{.SavedAt}}</small>{{end}}</dd>
+    </dl>
+
+    <fieldset role="group">
+        <button command="show-modal" commandfor="edit-dialog">Edit profile</button>
+        <a href="#edit-dialog" role="button" class="secondary outline">Open via URL hash</a>
+    </fieldset>
+
+    {{.lvt.FlashTag "success"}}
+
+    <dialog id="edit-dialog">
+        <article>
+            <header>
+                <h4>Edit profile</h4>
+            </header>
+            <form name="save">
+                <label>
+                    Name
+                    <input name="name" value="{{.Name}}" required minlength="3" {{.lvt.AriaInvalid "name"}}>
+                    {{.lvt.ErrorTag "name"}}
+                </label>
+                <label>
+                    Email
+                    <input type="email" name="email" value="{{.Email}}" required {{.lvt.AriaInvalid "email"}}>
+                    {{.lvt.ErrorTag "email"}}
+                </label>
+                <footer>
+                    <fieldset role="group">
+                        <button name="save" type="submit">Save</button>
+                        <button type="button" command="close" commandfor="edit-dialog" class="secondary">Cancel</button>
+                    </fieldset>
+                </footer>
+            </form>
+        </article>
+    </dialog>
+</article>
+{{end}}

--- a/patterns/templates/navigation/modal-dialog.tmpl
+++ b/patterns/templates/navigation/modal-dialog.tmpl
@@ -20,7 +20,7 @@
             <header>
                 <h4>Edit profile</h4>
             </header>
-            <form method="POST" name="save">
+            <form method="POST">
                 <label>
                     Name
                     <input name="name" value="{{.Name}}" required minlength="3" {{.lvt.AriaInvalid "name"}}>

--- a/patterns/templates/navigation/modal-dialog.tmpl
+++ b/patterns/templates/navigation/modal-dialog.tmpl
@@ -20,7 +20,7 @@
             <header>
                 <h4>Edit profile</h4>
             </header>
-            <form name="save">
+            <form method="POST" name="save">
                 <label>
                     Name
                     <input name="name" value="{{.Name}}" required minlength="3" {{.lvt.AriaInvalid "name"}}>

--- a/patterns/templates/navigation/spa-navigation.tmpl
+++ b/patterns/templates/navigation/spa-navigation.tmpl
@@ -29,7 +29,7 @@
     <section>
         <h4>Opt-out (<code>lvt-nav:no-intercept</code>)</h4>
         <p>External links should opt out so the browser handles them natively.</p>
-        <p><a href="https://example.com" lvt-nav:no-intercept rel="noopener" target="_blank">example.com</a> &mdash; opt-out via <code>lvt-nav:no-intercept</code></p>
+        <p><a href="https://example.com" lvt-nav:no-intercept rel="noopener noreferrer" target="_blank">example.com</a> &mdash; opt-out via <code>lvt-nav:no-intercept</code></p>
     </section>
 </article>
 {{end}}

--- a/patterns/templates/navigation/spa-navigation.tmpl
+++ b/patterns/templates/navigation/spa-navigation.tmpl
@@ -1,0 +1,35 @@
+{{define "content"}}
+<article>
+    <h3>SPA Navigation</h3>
+    <p><small>Every <code>&lt;a&gt;</code> link inside the LiveTemplate wrapper is auto-intercepted. Same-pathname links use the in-band WebSocket <code>__navigate__</code> action; cross-pathname links fetch and reconnect transparently. External targets opt out with <code>lvt-nav:no-intercept</code>.</small></p>
+
+    <section>
+        <h4>Same-pathname (in-band <code>__navigate__</code>)</h4>
+        <p>Click these to update <code>?step=</code> without an HTTP round-trip. The page does not reload &mdash; only this section re-renders.</p>
+        <nav aria-label="Step">
+            <ul>
+                <li><a href="?step=1" {{if eq .Step 1}}aria-current="page"{{end}}>Step 1</a></li>
+                <li><a href="?step=2" {{if eq .Step 2}}aria-current="page"{{end}}>Step 2</a></li>
+                <li><a href="?step=3" {{if eq .Step 3}}aria-current="page"{{end}}>Step 3</a></li>
+            </ul>
+        </nav>
+        <p><strong>Step {{.Step}} of 3.</strong></p>
+    </section>
+
+    <section>
+        <h4>Cross-pathname (WebSocket reconnect)</h4>
+        <p>Each pattern is its own handler with its own <code>data-lvt-id</code>. Clicking these links triggers a fetch + DOM swap + WebSocket reconnect &mdash; <strong>without</strong> a hard page reload.</p>
+        <ul>
+            <li><a href="/patterns/navigation/modal-dialog">Modal Dialog</a></li>
+            <li><a href="/patterns/navigation/tabs">Tabs (HATEOAS)</a></li>
+            <li><a href="/">Back to index</a></li>
+        </ul>
+    </section>
+
+    <section>
+        <h4>Opt-out (<code>lvt-nav:no-intercept</code>)</h4>
+        <p>External links should opt out so the browser handles them natively.</p>
+        <p><a href="https://example.com" lvt-nav:no-intercept rel="noopener" target="_blank">example.com</a> &mdash; opt-out via <code>lvt-nav:no-intercept</code></p>
+    </section>
+</article>
+{{end}}

--- a/patterns/templates/navigation/spa-navigation.tmpl
+++ b/patterns/templates/navigation/spa-navigation.tmpl
@@ -13,7 +13,7 @@
                 <li><a href="?step=3" {{if eq .Step 3}}aria-current="page"{{end}}>Step 3</a></li>
             </ul>
         </nav>
-        <p><strong>Step {{.Step}} of 3.</strong></p>
+        <p><strong>Step {{.Step}} of 3</strong>.</p>
     </section>
 
     <section>

--- a/patterns/templates/navigation/tabs.tmpl
+++ b/patterns/templates/navigation/tabs.tmpl
@@ -16,19 +16,15 @@
         <h4>Overview</h4>
         <p>This pattern uses a single <code>Mount</code> handler reading the <code>tab</code> query parameter. The active link is marked with <code>aria-current="page"</code> for screen readers and visually styled by Pico CSS.</p>
     </section>
-    {{end}}
-
-    {{if eq .ActiveTab "settings"}}
+    {{else if eq .ActiveTab "settings"}}
     <section>
         <h4>Settings</h4>
         <p>Tab content is rendered server-side from the same template — switching tabs is a re-render, not a partial fragment. Bookmark <code>?tab=settings</code> and the deep link works on next load too.</p>
     </section>
-    {{end}}
-
-    {{if eq .ActiveTab "activity"}}
+    {{else if eq .ActiveTab "activity"}}
     <section>
         <h4>Activity</h4>
-        <p>Unknown <code>tab</code> values fall back silently to <strong>Overview</strong>. The valid set lives in <code>validTabs</code> on the controller; bookmarks with stale values stay safe.</p>
+        <p>Unknown <code>tab</code> values fall back silently to <strong>Overview</strong>. The valid set lives in a <code>validTabs</code> allowlist; bookmarks with stale values stay safe.</p>
     </section>
     {{end}}
 </article>

--- a/patterns/templates/navigation/tabs.tmpl
+++ b/patterns/templates/navigation/tabs.tmpl
@@ -1,0 +1,35 @@
+{{define "content"}}
+<article>
+    <h3>Tabs (HATEOAS)</h3>
+    <p><small>Server-driven tabs. Each tab is a query-param link (<code>?tab=…</code>); the framework intercepts the click and routes it through the WebSocket via the in-band <code>__navigate__</code> action (server v0.8.19+, client v0.8.26+). No HTTP round-trip; <code>Mount()</code> re-runs with the new param.</small></p>
+
+    <nav aria-label="Sections">
+        <ul>
+            <li><a href="?tab=overview" {{if eq .ActiveTab "overview"}}aria-current="page"{{end}}>Overview</a></li>
+            <li><a href="?tab=settings" {{if eq .ActiveTab "settings"}}aria-current="page"{{end}}>Settings</a></li>
+            <li><a href="?tab=activity" {{if eq .ActiveTab "activity"}}aria-current="page"{{end}}>Activity</a></li>
+        </ul>
+    </nav>
+
+    {{if eq .ActiveTab "overview"}}
+    <section>
+        <h4>Overview</h4>
+        <p>This pattern uses a single <code>Mount</code> handler reading the <code>tab</code> query parameter. The active link is marked with <code>aria-current="page"</code> for screen readers and visually styled by Pico CSS.</p>
+    </section>
+    {{end}}
+
+    {{if eq .ActiveTab "settings"}}
+    <section>
+        <h4>Settings</h4>
+        <p>Tab content is rendered server-side from the same template — switching tabs is a re-render, not a partial fragment. Bookmark <code>?tab=settings</code> and the deep link works on next load too.</p>
+    </section>
+    {{end}}
+
+    {{if eq .ActiveTab "activity"}}
+    <section>
+        <h4>Activity</h4>
+        <p>Unknown <code>tab</code> values fall back silently to <strong>Overview</strong>. The valid set lives in <code>validTabs</code> on the controller; bookmarks with stale values stay safe.</p>
+    </section>
+    {{end}}
+</article>
+{{end}}


### PR DESCRIPTION
## Summary

Implements **Session 4** of the [patterns example proposal](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/patterns.md) — five new patterns under a new "Dialogs, Tabs & Navigation" category covering the Tier-1/Tier-2 navigation primitives LiveTemplate exposes on top of native browser features.

| #  | Pattern             | Tier | Notes                                                                                  |
|----|---------------------|------|----------------------------------------------------------------------------------------|
| 17 | Modal Dialog        | 1    | Native `<dialog>` + `command`/`commandfor` + hash deep linking; the invalid-form path exercises the client v0.8.33 morphdom fix (errors render inside the still-open dialog). |
| 18 | Confirm Dialog      | 1    | Per-item `<dialog id="confirm-{{.ID}}">`; uses `<button name="delete" value="{{.ID}}">` (project convention) — no hidden inputs. |
| 19 | Tabs (HATEOAS)      | 1    | `<a href="?tab=…">` driven by the in-band `__navigate__` WebSocket action (server v0.8.19+, client v0.8.26+). Mount-only controller. |
| 20 | SPA Navigation      | 1    | Explainer page covering same-pathname `__navigate__`, cross-pathname reconnect, and the `lvt-nav:no-intercept` opt-out. |
| 21 | Keyboard Shortcuts  | 2    | `lvt-on:window:keydown` + `lvt-key` for a command-palette-style overlay, plus a Tier-1 form fallback. |

Library bumped to v0.8.21 (from a stale v0.8.19 pre-release pseudo-version). All five Category 5 entries in `data.go` flipped to `Implemented:true`. `patterns/patterns` (compiled binary) added to `.gitignore`.

## Test plan

- [x] All five new pattern handlers compile clean (`go vet` ✓, `go build` ✓)
- [x] `TestModalDialog` — open via button + hash; invalid submit keeps dialog open with field errors (v0.8.33 proof point); valid submit produces success flash; browser Back closes
- [x] `TestConfirmDialog` — per-item open; Cancel doesn't delete; Confirm deletes; per-item `#confirm-N` hash link auto-activates the right dialog
- [x] `TestTabs` — default tab is Overview; tab clicks update `aria-current="page"`; **`Tab_Switch_Uses_WebSocket_Not_HTTP`** asserts no HTTP fetch fires; invalid tab falls back to default
- [x] `TestSPANavigation` — `Same_Pathname_Step_Update_No_HTTP` asserts no fetch; external link carries `lvt-nav:no-intercept`
- [x] `TestKeyboardShortcuts` — `/` opens panel, Escape closes; activity log accumulates; in-panel form submit also closes (Tier-1 fallback)
- [x] `cross_handler_nav_test.go` — three new subtests for stale-DOM regression, Tabs WS-only switch, and SPA cross-pathname reconnect

Two consecutive runs of all six new test functions pass locally (~100s and ~112s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)