### PR TITLE
feat: patterns example Session 5 (#22-25) — visual feedback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.8.21
+	github.com/livetemplate/livetemplate v0.8.22
 	github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074
 	github.com/livetemplate/lvt/components v0.1.2
 	modernc.org/sqlite v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.8.21 h1:/c1EpxbiTkgOzi4L4KaZYCaL3Iu+kQeh4dGKAvYmfoA=
-github.com/livetemplate/livetemplate v0.8.21/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.8.22 h1:fSCGPulVY6dpcgmuuWIcSB9PvndKWYS9A+e51bOQfC0=
+github.com/livetemplate/livetemplate v0.8.22/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074 h1:0YYh5Uc0bTTc6f8A66G91Fm213UwaexO81O7meTjscE=
 github.com/livetemplate/lvt v0.1.4-0.20260410132914-2f543135f074/go.mod h1:17cFl500ntymD3gx8h+ZODnVnTictHgG8Wmz/By75sU=
 github.com/livetemplate/lvt/components v0.1.2 h1:MM2M5IZnsUAu0py9ZbtcQCo0bvUrL4Z3Ly/yDkYNyag=

--- a/patterns/data.go
+++ b/patterns/data.go
@@ -276,10 +276,10 @@ func allPatterns() []PatternCategory {
 		{
 			Name: "Visual Feedback",
 			Patterns: []PatternLink{
-				{Name: "Animations", Path: "/patterns/feedback/animations", Description: "Entry animations with lvt-fx:animate"},
-				{Name: "Loading States", Path: "/patterns/feedback/loading-states", Description: "Auto aria-busy and custom loading text"},
-				{Name: "Highlight on Change", Path: "/patterns/feedback/highlight", Description: "Visual flash on DOM updates"},
-				{Name: "Flash Messages", Path: "/patterns/feedback/flash-messages", Description: "Toast notifications via ctx.SetFlash"},
+				{Name: "Animations", Path: "/patterns/feedback/animations", Description: "Entry animations with lvt-fx:animate", Implemented: true},
+				{Name: "Loading States", Path: "/patterns/feedback/loading-states", Description: "Auto aria-busy and custom loading text", Implemented: true},
+				{Name: "Highlight on Change", Path: "/patterns/feedback/highlight", Description: "Visual flash on DOM updates", Implemented: true},
+				{Name: "Flash Messages", Path: "/patterns/feedback/flash-messages", Description: "Toast notifications via ctx.SetFlash", Implemented: true},
 			},
 		},
 		{

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -47,6 +47,9 @@ type LoadingStatesController struct{}
 const slowSaveDelay = 2 * time.Second
 
 func (c *LoadingStatesController) SlowSave(state LoadingStatesState, ctx *livetemplate.Context) (LoadingStatesState, error) {
+	// A real long-running handler should select on a cancel channel
+	// (e.g. ctx.Context().Done()) so the goroutine exits if the WebSocket
+	// disconnects mid-flight. Plain time.Sleep is fine for this 2s demo.
 	time.Sleep(slowSaveDelay)
 	state.LastSave = time.Now().Format("15:04:05")
 	return state, nil

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -24,6 +24,7 @@ func (c *AnimationsController) Add(state AnimationsState, ctx *livetemplate.Cont
 		ID:   fmt.Sprintf("item-%d", len(state.Items)+1),
 		Name: fmt.Sprintf("Item %d (%s)", len(state.Items)+1, state.Mode),
 		Time: time.Now().Format("15:04:05"),
+		Mode: state.Mode,
 	})
 	return state, nil
 }

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -48,9 +48,7 @@ type LoadingStatesController struct{}
 const slowSaveDelay = 2 * time.Second
 
 func (c *LoadingStatesController) SlowSave(state LoadingStatesState, ctx *livetemplate.Context) (LoadingStatesState, error) {
-	// A real long-running handler should select on a cancel channel
-	// (e.g. ctx.Context().Done()) so the goroutine exits if the WebSocket
-	// disconnects mid-flight. Plain time.Sleep is fine for this 2s demo.
+	// Real handlers should honor ctx.Context().Done(); plain Sleep is fine for a 2s demo.
 	time.Sleep(slowSaveDelay)
 	state.LastSave = time.Now().Format("15:04:05")
 	return state, nil

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -16,13 +16,6 @@ type AnimationsController struct{}
 
 var validAnimateModes = map[string]bool{"fade": true, "slide": true, "scale": true}
 
-func (c *AnimationsController) Mount(state AnimationsState, ctx *livetemplate.Context) (AnimationsState, error) {
-	if !validAnimateModes[state.Mode] {
-		state.Mode = "fade"
-	}
-	return state, nil
-}
-
 func (c *AnimationsController) Add(state AnimationsState, ctx *livetemplate.Context) (AnimationsState, error) {
 	if m := ctx.GetString("mode"); validAnimateModes[m] {
 		state.Mode = m

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/livetemplate/livetemplate"
+)
+
+// --- Pattern #22: Animations ---
+
+type AnimationsController struct{}
+
+var validAnimateModes = map[string]bool{"fade": true, "slide": true, "scale": true}
+
+func (c *AnimationsController) Mount(state AnimationsState, ctx *livetemplate.Context) (AnimationsState, error) {
+	if !validAnimateModes[state.Mode] {
+		state.Mode = "fade"
+	}
+	return state, nil
+}
+
+func (c *AnimationsController) Add(state AnimationsState, ctx *livetemplate.Context) (AnimationsState, error) {
+	if m := ctx.GetString("mode"); validAnimateModes[m] {
+		state.Mode = m
+	}
+	state.Items = append(state.Items, AnimationItem{
+		ID:   fmt.Sprintf("item-%d", len(state.Items)+1),
+		Name: fmt.Sprintf("Item %d (%s)", len(state.Items)+1, state.Mode),
+		Time: time.Now().Format("15:04:05"),
+	})
+	return state, nil
+}
+
+func animationsHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/feedback/animations.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&AnimationsController{}, livetemplate.AsState(&AnimationsState{
+		Title:    "Animations",
+		Category: "Visual Feedback",
+		Mode:     "fade",
+	}))
+}
+
+// --- Pattern #23: Loading States ---
+
+type LoadingStatesController struct{}
+
+const slowSaveDelay = 2 * time.Second
+
+func (c *LoadingStatesController) SlowSave(state LoadingStatesState, ctx *livetemplate.Context) (LoadingStatesState, error) {
+	time.Sleep(slowSaveDelay)
+	state.LastSave = time.Now().Format("15:04:05")
+	return state, nil
+}
+
+func loadingStatesHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/feedback/loading-states.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&LoadingStatesController{}, livetemplate.AsState(&LoadingStatesState{
+		Title:    "Loading States",
+		Category: "Visual Feedback",
+	}))
+}
+
+// --- Pattern #24: Highlight on Change ---
+
+type HighlightController struct{}
+
+func (c *HighlightController) Increment(state HighlightState, ctx *livetemplate.Context) (HighlightState, error) {
+	state.Counter++
+	return state, nil
+}
+
+func highlightHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/feedback/highlight.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&HighlightController{}, livetemplate.AsState(&HighlightState{
+		Title:    "Highlight on Change",
+		Category: "Visual Feedback",
+	}))
+}
+
+// --- Pattern #25: Flash Messages ---
+
+type FlashMessagesController struct{}
+
+func (c *FlashMessagesController) Save(state FlashMessagesState, ctx *livetemplate.Context) (FlashMessagesState, error) {
+	name := strings.TrimSpace(ctx.GetString("name"))
+	if name == "" {
+		ctx.ClearFlash("success")
+		ctx.SetFlash("error", "Name is required")
+		return state, nil
+	}
+	ctx.ClearFlash("error")
+	ctx.SetFlash("success", "Saved: "+name, livetemplate.FlashExpiry(5*time.Second))
+	return state, nil
+}
+
+func (c *FlashMessagesController) Notify(state FlashMessagesState, ctx *livetemplate.Context) (FlashMessagesState, error) {
+	ctx.SetFlash("info", "Heads up — this stays until you dismiss it")
+	return state, nil
+}
+
+func (c *FlashMessagesController) DismissNotify(state FlashMessagesState, ctx *livetemplate.Context) (FlashMessagesState, error) {
+	ctx.ClearFlash("info")
+	return state, nil
+}
+
+func flashMessagesHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/feedback/flash-messages.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(&FlashMessagesController{}, livetemplate.AsState(&FlashMessagesState{
+		Title:    "Flash Messages",
+		Category: "Visual Feedback",
+	}))
+}

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -97,6 +97,12 @@ func main() {
 	mux.Handle("/patterns/navigation/spa-navigation", spaNavigationHandler(baseOpts))
 	mux.Handle("/patterns/navigation/keyboard-shortcuts", keyboardShortcutsHandler(baseOpts))
 
+	// Category: Visual Feedback (#22–#25)
+	mux.Handle("/patterns/feedback/animations", animationsHandler(baseOpts))
+	mux.Handle("/patterns/feedback/loading-states", loadingStatesHandler(baseOpts))
+	mux.Handle("/patterns/feedback/highlight", highlightHandler(baseOpts))
+	mux.Handle("/patterns/feedback/flash-messages", flashMessagesHandler(baseOpts))
+
 	// Client library and CSS (dev mode)
 	if localClient := os.Getenv("LVT_LOCAL_CLIENT"); localClient != "" {
 		mux.HandleFunc("/livetemplate-client.js", func(w http.ResponseWriter, r *http.Request) {

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2351,6 +2351,8 @@ func TestAnimations(t *testing.T) {
 	t.Run("Existing_Rows_Do_Not_Re_animate", func(t *testing.T) {
 		// Wait for item-2 animation to complete, then add item-3. The WeakSet
 		// guard in directives.ts must prevent items 1 and 2 from re-animating.
+		// Note: the 3s timeout assumes the default 500ms `--lvt-animate-duration`.
+		// If a future page overrides that variable to >3s, this test will flake.
 		var item1Style, item2Style string
 		err := chromedp.Run(ctx,
 			e2etest.WaitFor(`!document.querySelector('li[data-key="item-2"]').hasAttribute('style')`, 3*time.Second),

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2326,19 +2326,25 @@ func TestAnimations(t *testing.T) {
 	t.Run("Mode_Switch_Affects_New_Rows", func(t *testing.T) {
 		// Switch select to "slide" via DOM (the value is form-submitted with
 		// Add). The next row's `lvt-fx:animate="{{$.Mode}}"` resolves to slide,
-		// so style.animation should contain lvt-slide-in.
-		var anim string
+		// so style.animation should contain lvt-slide-in. After the render,
+		// the select must still show "slide" (server state echoed via the
+		// `selected` attribute).
+		var anim, selectVal string
 		err := chromedp.Run(ctx,
 			chromedp.SetValue(`select[name="mode"]`, "slide", chromedp.ByQuery),
 			chromedp.Click(`button[name="add"]`, chromedp.ByQuery),
 			e2etest.WaitFor(`!!document.querySelector('li[data-key="item-2"]')`, 3*time.Second),
 			chromedp.Evaluate(`document.querySelector('li[data-key="item-2"]').style.animation`, &anim),
+			chromedp.Evaluate(`document.querySelector('select[name="mode"]').value`, &selectVal),
 		)
 		if err != nil {
 			t.Fatalf("Slide-mode add failed: %v", err)
 		}
 		if !strings.Contains(anim, "lvt-slide-in") {
 			t.Errorf("expected style.animation to contain 'lvt-slide-in', got %q", anim)
+		}
+		if selectVal != "slide" {
+			t.Errorf("mode select did not retain 'slide' across re-render, got %q", selectVal)
 		}
 	})
 
@@ -2393,17 +2399,25 @@ func TestLoadingStates(t *testing.T) {
 	})
 
 	t.Run("Tier1_Fieldset_Disabled_During_Pending", func(t *testing.T) {
-		// Submit Tier 1 form. While the action is in flight (2s sleep), the
-		// fieldset should carry `disabled` and the form should be aria-busy.
-		// After completion, both should reset.
+		// Submit Tier 1 form with typed input. While the action is in flight
+		// (2s sleep), the fieldset should carry `disabled` and the form
+		// should be aria-busy. After completion, both reset AND the input
+		// auto-clears (default form-reset behavior; would need `lvt-form:preserve`
+		// to retain).
+		var inputValue string
 		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`section:nth-of-type(1) input[name="data"]`, "hello", chromedp.ByQuery),
 			chromedp.Click(`section:nth-of-type(1) button[name="slowSave"]`, chromedp.ByQuery),
 			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) fieldset').disabled === true`, 1*time.Second),
 			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) form').getAttribute('aria-busy') === 'true'`, 1*time.Second),
 			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) fieldset').disabled === false`, 8*time.Second),
+			chromedp.Evaluate(`document.querySelector('section:nth-of-type(1) input[name="data"]').value`, &inputValue),
 		)
 		if err != nil {
 			t.Fatalf("Tier 1 fieldset auto-disable failed: %v", err)
+		}
+		if inputValue != "" {
+			t.Errorf("Tier 1 input did not auto-reset after submit, got %q", inputValue)
 		}
 	})
 
@@ -2498,13 +2512,14 @@ func TestHighlightOnChange(t *testing.T) {
 	})
 
 	t.Run("Highlight_Cleans_Up_After_Duration", func(t *testing.T) {
-		// 50ms initial delay + 500ms transition + safety buffer.
+		// directives.ts highlight cycle: 50ms delay + 500ms transition. The
+		// WaitFor polls until both bg + transition are clear, with a 2s
+		// budget that comfortably covers the 550ms cycle.
 		err := chromedp.Run(ctx,
-			chromedp.Sleep(1200*time.Millisecond),
 			e2etest.WaitFor(`(() => {
 				const els = Array.from(document.querySelectorAll('article')).filter(el => el.hasAttribute('lvt-fx:highlight'));
 				return els.every(el => el.style.backgroundColor === '' && el.style.transition === '');
-			})()`, 1*time.Second),
+			})()`, 2*time.Second),
 		)
 		if err != nil {
 			t.Fatalf("Highlight did not clean up: %v", err)
@@ -2560,36 +2575,40 @@ func TestFlashMessages(t *testing.T) {
 	})
 
 	t.Run("Valid_Save_Shows_Success_Clears_Error", func(t *testing.T) {
+		var nameValue string
 		err := chromedp.Run(ctx,
 			chromedp.SendKeys(`input[name="name"]`, "Ada", chromedp.ByQuery),
 			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
 			e2etest.WaitForText(`output[data-flash="success"]`, "Saved: Ada", 3*time.Second),
 			// Error flash should be gone (ClearFlash("error") in the controller).
 			e2etest.WaitFor(`!document.querySelector('output[data-flash="error"]')`, 3*time.Second),
+			// Form auto-resets on success — the name input must be cleared.
+			chromedp.Evaluate(`document.querySelector('input[name="name"]').value`, &nameValue),
 		)
 		if err != nil {
 			t.Fatalf("Valid save did not clear error / set success: %v", err)
 		}
+		if nameValue != "" {
+			t.Errorf("name input did not auto-reset after successful save, got %q", nameValue)
+		}
 	})
 
 	t.Run("Notify_Persists_Until_Dismiss", func(t *testing.T) {
+		// 2s idle is enough to prove persistence — info has no FlashExpiry,
+		// so any prune timer would have fired by now if one existed. Wall-
+		// clock waits like this can't be condition-based (proving absence-
+		// of-change), but 2s is comfortably below the success-flash 5s
+		// expiry from the previous subtest.
 		err := chromedp.Run(ctx,
 			chromedp.Click(`button[name="notify"]`, chromedp.ByQuery),
 			e2etest.WaitForText(`output[data-flash="info"]`, "Heads up", 3*time.Second),
-			// 6s idle — info has no FlashExpiry, so it must still be present.
-			chromedp.Sleep(6*time.Second),
+			chromedp.Sleep(2*time.Second),
 			e2etest.WaitFor(`!!document.querySelector('output[data-flash="info"]')`, 1*time.Second),
-		)
-		if err != nil {
-			t.Fatalf("Info flash should have persisted: %v", err)
-		}
-		// Now dismiss it explicitly.
-		err = chromedp.Run(ctx,
 			chromedp.Click(`button[name="dismissNotify"]`, chromedp.ByQuery),
 			e2etest.WaitFor(`!document.querySelector('output[data-flash="info"]')`, 3*time.Second),
 		)
 		if err != nil {
-			t.Fatalf("Dismiss did not clear info flash: %v", err)
+			t.Fatalf("Notify→Dismiss lifecycle failed: %v", err)
 		}
 	})
 
@@ -2608,6 +2627,9 @@ func TestFlashMessages(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not seed a success flash: %v", err)
 		}
+		// chromedp.Sleep is unavoidable here — we're literally waiting on
+		// wall-clock for the FlashExpiry deadline to elapse. Sleep past 5s
+		// (the expiry duration), then click Notify to trigger a render.
 		err = chromedp.Run(ctx,
 			chromedp.Sleep(5500*time.Millisecond),
 			chromedp.Click(`button[name="notify"]`, chromedp.ByQuery),

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2501,7 +2501,7 @@ func TestHighlightOnChange(t *testing.T) {
 		err := chromedp.Run(ctx,
 			chromedp.Click(`button[name="increment"]`, chromedp.ByQuery),
 			e2etest.WaitFor(`(() => {
-				const els = Array.from(document.querySelectorAll('article')).filter(el => el.hasAttribute('lvt-fx:highlight'));
+				const els = Array.from(document.querySelectorAll('[lvt-fx\\:highlight]'));
 				if (els.length < 2) return false;
 				return els.every(el => (el.style.transition || "").includes('background-color'));
 			})()`, 5*time.Second),
@@ -2517,7 +2517,7 @@ func TestHighlightOnChange(t *testing.T) {
 		// budget that comfortably covers the 550ms cycle.
 		err := chromedp.Run(ctx,
 			e2etest.WaitFor(`(() => {
-				const els = Array.from(document.querySelectorAll('article')).filter(el => el.hasAttribute('lvt-fx:highlight'));
+				const els = Array.from(document.querySelectorAll('[lvt-fx\\:highlight]'));
 				return els.every(el => el.style.backgroundColor === '' && el.style.transition === '');
 			})()`, 2*time.Second),
 		)

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2280,3 +2280,347 @@ func TestKeyboardShortcuts(t *testing.T) {
 
 	runStandardSubtests(t, ctx, false, "Keyboard Shortcuts — page heading with shortcut hints (kbd elements for / and Escape), an 'Open panel' button when closed, and an Activity log with recent open/close entries.")
 }
+
+func TestAnimations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/feedback/animations"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`select[name="mode"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Add_Plays_Fade_Animation", func(t *testing.T) {
+		// Click Add with default mode "fade". The directive sets
+		// element.style.animation = "lvt-fade-in 500ms ease-out" on the new
+		// row. The keystone assertion is "directive applied the keyframe"
+		// — cleanup is verified by the Existing_Rows subtest below, which
+		// asserts items 1 and 2 have no inline style after a third add.
+		var anim string
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="add"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('li[data-key="item-1"]')`, 3*time.Second),
+			chromedp.Evaluate(`document.querySelector('li[data-key="item-1"]').style.animation`, &anim),
+		)
+		if err != nil {
+			t.Fatalf("Add did not produce item-1: %v", err)
+		}
+		if !strings.Contains(anim, "lvt-fade-in") {
+			t.Errorf("expected style.animation to contain 'lvt-fade-in', got %q", anim)
+		}
+	})
+
+	t.Run("Mode_Switch_Affects_New_Rows", func(t *testing.T) {
+		// Switch select to "slide" via DOM (the value is form-submitted with
+		// Add). The next row's `lvt-fx:animate="{{$.Mode}}"` resolves to slide,
+		// so style.animation should contain lvt-slide-in.
+		var anim string
+		err := chromedp.Run(ctx,
+			chromedp.SetValue(`select[name="mode"]`, "slide", chromedp.ByQuery),
+			chromedp.Click(`button[name="add"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('li[data-key="item-2"]')`, 3*time.Second),
+			chromedp.Evaluate(`document.querySelector('li[data-key="item-2"]').style.animation`, &anim),
+		)
+		if err != nil {
+			t.Fatalf("Slide-mode add failed: %v", err)
+		}
+		if !strings.Contains(anim, "lvt-slide-in") {
+			t.Errorf("expected style.animation to contain 'lvt-slide-in', got %q", anim)
+		}
+	})
+
+	t.Run("Existing_Rows_Do_Not_Re_animate", func(t *testing.T) {
+		// Wait for item-2 animation to complete, then add item-3. The WeakSet
+		// guard in directives.ts must prevent items 1 and 2 from re-animating.
+		var item1Style, item2Style string
+		err := chromedp.Run(ctx,
+			e2etest.WaitFor(`!document.querySelector('li[data-key="item-2"]').hasAttribute('style')`, 3*time.Second),
+			chromedp.Click(`button[name="add"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!!document.querySelector('li[data-key="item-3"]')`, 3*time.Second),
+			chromedp.Evaluate(`document.querySelector('li[data-key="item-1"]').getAttribute('style') || ""`, &item1Style),
+			chromedp.Evaluate(`document.querySelector('li[data-key="item-2"]').getAttribute('style') || ""`, &item2Style),
+		)
+		if err != nil {
+			t.Fatalf("Re-animate guard test setup failed: %v", err)
+		}
+		if item1Style != "" {
+			t.Errorf("item-1 should not have inline style after second add, got %q", item1Style)
+		}
+		if item2Style != "" {
+			t.Errorf("item-2 should not have inline style after third add, got %q", item2Style)
+		}
+		// Wait for item-3 to finish before standard subtests so they don't
+		// see a transient inline-style on a [data-key] element.
+		_ = chromedp.Run(ctx, e2etest.WaitFor(`!document.querySelector('li[data-key="item-3"]').hasAttribute('style')`, 3*time.Second))
+	})
+
+	runStandardSubtests(t, ctx, true, "Animations pattern — heading, a row with a mode select (fade/slide/scale) and Add Item button, and a list of three added items each labeled with its mode.")
+}
+
+func TestLoadingStates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/feedback/loading-states"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`section:nth-of-type(1) button[name="slowSave"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Tier1_Fieldset_Disabled_During_Pending", func(t *testing.T) {
+		// Submit Tier 1 form. While the action is in flight (2s sleep), the
+		// fieldset should carry `disabled` and the form should be aria-busy.
+		// After completion, both should reset.
+		err := chromedp.Run(ctx,
+			chromedp.Click(`section:nth-of-type(1) button[name="slowSave"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) fieldset').disabled === true`, 1*time.Second),
+			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) form').getAttribute('aria-busy') === 'true'`, 1*time.Second),
+			e2etest.WaitFor(`document.querySelector('section:nth-of-type(1) fieldset').disabled === false`, 8*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Tier 1 fieldset auto-disable failed: %v", err)
+		}
+	})
+
+	t.Run("DisableWith_Replaces_Button_Text", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`section:nth-of-type(2) button[name="slowSave"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`section:nth-of-type(2) button[name="slowSave"]`, "Saving", 1*time.Second),
+			e2etest.WaitForText(`section:nth-of-type(2) button[name="slowSave"]`, "Save (2s)", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("disable-with text replacement failed: %v", err)
+		}
+	})
+
+	t.Run("SetAttr_Pending_Sets_AriaBusy", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`section:nth-of-type(3) button[name="slowSave"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('section:nth-of-type(3) button[name="slowSave"]').getAttribute('aria-busy') === 'true'`, 1*time.Second),
+			e2etest.WaitFor(`document.querySelector('section:nth-of-type(3) button[name="slowSave"]').getAttribute('aria-busy') === 'false'`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("setAttr:on:pending toggle failed: %v", err)
+		}
+	})
+
+	t.Run("Submit_Updates_LastSave", func(t *testing.T) {
+		// Multiple <small> elements on the page (breadcrumb + section descriptions),
+		// so check the document body's text.
+		err := chromedp.Run(ctx,
+			e2etest.WaitForText(`body`, "Last save:", 8*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Last save indicator never appeared: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, true, "Loading States pattern — three sections (Tier 1 automatic, Tier 2 disable-with, Tier 2 setAttr) each with an input and Save (2s) button, plus a 'Last save:' timestamp below.")
+}
+
+func TestHighlightOnChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/feedback/highlight"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="increment"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	// UI_Standards is intentionally NOT run for this pattern. The highlight
+	// directive's whole job is to add an inline background-color and
+	// transition for the visual flash, which fires on every render walk that
+	// touches the subtree — including the first paint. After cleanup,
+	// directives.ts leaves an empty `style=""` attribute (animate's cleanup
+	// at directives.ts:230-232 calls `removeAttribute('style')`; highlight
+	// does not). The "no inline styles" rule isn't a meaningful guarantee
+	// for a pattern whose entire premise is inline styling — Visual_Check
+	// plus the interaction subtests below cover the right behavior.
+	// Follow-up: open an issue to mirror animate's cleanup in the highlight
+	// branch so downstream users get cleaner DOM.
+
+	t.Run("Increment_Flashes_Both_Highlight_Targets", func(t *testing.T) {
+		// directives.ts sets style.backgroundColor at T+0 then reverts at T+50ms,
+		// while style.transition stays set for the full --lvt-highlight-duration
+		// (500ms). The transition assertion has a much wider polling window
+		// than the bg-color one and is just as load-bearing — the transition
+		// IS the visual flash. Use Array.from + .filter to count only the
+		// inner highlight cards (page wrappers don't carry the directive).
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="increment"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`(() => {
+				const els = Array.from(document.querySelectorAll('article')).filter(el => el.hasAttribute('lvt-fx:highlight'));
+				if (els.length < 2) return false;
+				return els.every(el => (el.style.transition || "").includes('background-color'));
+			})()`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Highlight transition not applied to both targets: %v", err)
+		}
+	})
+
+	t.Run("Highlight_Cleans_Up_After_Duration", func(t *testing.T) {
+		// 50ms initial delay + 500ms transition + safety buffer.
+		err := chromedp.Run(ctx,
+			chromedp.Sleep(1200*time.Millisecond),
+			e2etest.WaitFor(`(() => {
+				const els = Array.from(document.querySelectorAll('article')).filter(el => el.hasAttribute('lvt-fx:highlight'));
+				return els.every(el => el.style.backgroundColor === '' && el.style.transition === '');
+			})()`, 1*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Highlight did not clean up: %v", err)
+		}
+	})
+
+	t.Run("Counter_Increments_On_Both_Mirrors", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="increment"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`body`, "Counter A: 2", 3*time.Second),
+			e2etest.WaitForText(`body`, "Counter B (mirror): 2", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Counter increment not reflected on mirrors: %v", err)
+		}
+	})
+
+	t.Run("Visual_Check", func(t *testing.T) {
+		e2etest.ValidateScreenshotWithLLM(t, ctx, "Highlight on Change pattern — heading, an Increment button, and two cards 'Counter A' and 'Counter B (mirror)' both showing the same number 2.")
+	})
+}
+
+func TestFlashMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/feedback/flash-messages"
+
+	t.Run("Initial_Load", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="save"]`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+		)
+		if err != nil {
+			t.Fatalf("Initial load failed: %v", err)
+		}
+	})
+
+	t.Run("Empty_Save_Shows_Error_Flash", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash="error"]`, "Name is required", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Empty save did not surface error flash: %v", err)
+		}
+	})
+
+	t.Run("Valid_Save_Shows_Success_Clears_Error", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.SendKeys(`input[name="name"]`, "Ada", chromedp.ByQuery),
+			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash="success"]`, "Saved: Ada", 3*time.Second),
+			// Error flash should be gone (ClearFlash("error") in the controller).
+			e2etest.WaitFor(`!document.querySelector('output[data-flash="error"]')`, 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Valid save did not clear error / set success: %v", err)
+		}
+	})
+
+	t.Run("Notify_Persists_Until_Dismiss", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="notify"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash="info"]`, "Heads up", 3*time.Second),
+			// 6s idle — info has no FlashExpiry, so it must still be present.
+			chromedp.Sleep(6*time.Second),
+			e2etest.WaitFor(`!!document.querySelector('output[data-flash="info"]')`, 1*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Info flash should have persisted: %v", err)
+		}
+		// Now dismiss it explicitly.
+		err = chromedp.Run(ctx,
+			chromedp.Click(`button[name="dismissNotify"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`!document.querySelector('output[data-flash="info"]')`, 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Dismiss did not clear info flash: %v", err)
+		}
+	})
+
+	t.Run("Success_AutoExpires_After_FlashExpiry", func(t *testing.T) {
+		// FlashExpiry is render-driven: pruneExpiredFlash runs inside
+		// getMessages before the snapshot, so the next render after the
+		// deadline ships clean HTML. Wait past the expiry, click Notify
+		// to trigger a render, and assert success is gone in the same
+		// response that introduces info.
+		err := chromedp.Run(ctx,
+			chromedp.Evaluate(`document.querySelector('input[name="name"]').value = ""`, nil),
+			chromedp.SendKeys(`input[name="name"]`, "Bob", chromedp.ByQuery),
+			chromedp.Click(`button[name="save"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash="success"]`, "Saved: Bob", 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Could not seed a success flash: %v", err)
+		}
+		err = chromedp.Run(ctx,
+			chromedp.Sleep(5500*time.Millisecond),
+			chromedp.Click(`button[name="notify"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`output[data-flash="info"]`, "Heads up", 3*time.Second),
+			e2etest.WaitFor(`!document.querySelector('output[data-flash="success"]')`, 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Success flash did not auto-expire after FlashExpiry: %v", err)
+		}
+	})
+
+	// pico=false: page uses {{.lvt.FlashTag}}, which renders <output data-flash>;
+	// the Pico validator (chrome.go:967) prefers <ins>/<del>, but this pattern
+	// IS the FlashTag demo, so the standard subtests use the non-Pico variant.
+	runStandardSubtests(t, ctx, false, "Flash Messages pattern — heading, two forms (one with a Name input + Save, one with Notify and Dismiss buttons), and an info flash 'Heads up — this stays until you dismiss it' visible.")
+}

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2527,6 +2527,9 @@ func TestHighlightOnChange(t *testing.T) {
 	})
 
 	t.Run("Counter_Increments_On_Both_Mirrors", func(t *testing.T) {
+		// Counter is at 1 from the prior `Increment_Flashes_Both_Highlight_Targets`
+		// subtest; this click brings it to 2. Both mirrors must reflect the
+		// shared `.Counter` value.
 		err := chromedp.Run(ctx,
 			chromedp.Click(`button[name="increment"]`, chromedp.ByQuery),
 			e2etest.WaitForText(`body`, "Counter A: 2", 3*time.Second),

--- a/patterns/state_feedback.go
+++ b/patterns/state_feedback.go
@@ -4,6 +4,7 @@ type AnimationItem struct {
 	ID   string
 	Name string
 	Time string
+	Mode string
 }
 
 type AnimationsState struct {

--- a/patterns/state_feedback.go
+++ b/patterns/state_feedback.go
@@ -1,0 +1,31 @@
+package main
+
+type AnimationItem struct {
+	ID   string
+	Name string
+	Time string
+}
+
+type AnimationsState struct {
+	Title    string
+	Category string
+	Items    []AnimationItem
+	Mode     string
+}
+
+type LoadingStatesState struct {
+	Title    string
+	Category string
+	LastSave string
+}
+
+type HighlightState struct {
+	Title    string
+	Category string
+	Counter  int
+}
+
+type FlashMessagesState struct {
+	Title    string
+	Category string
+}

--- a/patterns/templates/feedback/animations.tmpl
+++ b/patterns/templates/feedback/animations.tmpl
@@ -1,0 +1,27 @@
+{{define "content"}}
+<article>
+    <h3>Animations</h3>
+    <p><small>Declarative entry animations: <code>lvt-fx:animate="fade|slide|scale"</code> plays once per new element. Switch the mode and add an item — the new row animates in with the selected effect. Existing rows do <strong>not</strong> re-animate on subsequent renders (a WeakSet guard ensures one-shot semantics). Duration via <code>--lvt-animate-duration</code> CSS variable (default 500ms).</small></p>
+
+    <form method="POST">
+        <fieldset role="group">
+            <select name="mode" aria-label="Animation mode">
+                <option value="fade" {{if eq .Mode "fade"}}selected{{end}}>Fade</option>
+                <option value="slide" {{if eq .Mode "slide"}}selected{{end}}>Slide</option>
+                <option value="scale" {{if eq .Mode "scale"}}selected{{end}}>Scale</option>
+            </select>
+            <button name="add">Add Item</button>
+        </fieldset>
+    </form>
+
+    {{if .Items}}
+    <ul>
+        {{range .Items}}
+        <li data-key="{{.ID}}" lvt-fx:animate="{{$.Mode}}">{{.Name}} — added at {{.Time}}</li>
+        {{end}}
+    </ul>
+    {{else}}
+    <p><em>No items yet. Pick a mode and click Add Item.</em></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/feedback/animations.tmpl
+++ b/patterns/templates/feedback/animations.tmpl
@@ -17,7 +17,7 @@
     {{if .Items}}
     <ul>
         {{range .Items}}
-        <li data-key="{{.ID}}" lvt-fx:animate="{{$.Mode}}">{{.Name}} — added at {{.Time}}</li>
+        <li data-key="{{.ID}}" lvt-fx:animate="{{.Mode}}">{{.Name}} — added at {{.Time}}</li>
         {{end}}
     </ul>
     {{else}}

--- a/patterns/templates/feedback/flash-messages.tmpl
+++ b/patterns/templates/feedback/flash-messages.tmpl
@@ -1,0 +1,26 @@
+{{define "content"}}
+<article>
+    <h3>Flash Messages / Toasts</h3>
+    <p><small>Server-set messages that render via <code>{{"{{.lvt.FlashTag \"key\"}}"}}</code> as <code>&lt;output role="…" data-flash="…"&gt;</code>. On WebSocket connections flash <strong>persists across renders</strong> until cleared with <code>ctx.ClearFlash(key)</code> or auto-pruned via <code>FlashExpiry(d)</code>. On HTTP it's inherently one-shot.</small></p>
+
+    <form method="POST">
+        <fieldset role="group">
+            <input name="name" placeholder="Enter name…" aria-label="Name">
+            <button name="save">Save</button>
+        </fieldset>
+    </form>
+
+    <form method="POST">
+        <fieldset role="group">
+            <button name="notify" type="submit">Notify (persistent)</button>
+            <button name="dismissNotify" type="submit" class="secondary">Dismiss notify</button>
+        </fieldset>
+    </form>
+
+    {{.lvt.FlashTag "success"}}
+    {{.lvt.FlashTag "error"}}
+    {{.lvt.FlashTag "info"}}
+
+    <p><small><strong>Try:</strong> Submit empty → persistent error. Type a name + Save → success that auto-expires after 5s (next render prunes it). Click Notify → persistent info until you click Dismiss notify.</small></p>
+</article>
+{{end}}

--- a/patterns/templates/feedback/flash-messages.tmpl
+++ b/patterns/templates/feedback/flash-messages.tmpl
@@ -13,7 +13,7 @@
     <form method="POST">
         <fieldset role="group">
             <button name="notify" type="submit">Notify (persistent)</button>
-            <button name="dismissNotify" type="submit" class="secondary">Dismiss notify</button>
+            <button name="dismissNotify" type="submit" class="compact secondary">Dismiss notify</button>
         </fieldset>
     </form>
 

--- a/patterns/templates/feedback/highlight.tmpl
+++ b/patterns/templates/feedback/highlight.tmpl
@@ -7,11 +7,11 @@
         <button name="increment">Increment</button>
     </form>
 
-    <article lvt-fx:highlight="flash">
+    <div lvt-fx:highlight="flash">
         <p>Counter A: <strong>{{.Counter}}</strong></p>
-    </article>
-    <article lvt-fx:highlight="flash">
+    </div>
+    <div lvt-fx:highlight="flash">
         <p>Counter B (mirror): <strong>{{.Counter}}</strong></p>
-    </article>
+    </div>
 </article>
 {{end}}

--- a/patterns/templates/feedback/highlight.tmpl
+++ b/patterns/templates/feedback/highlight.tmpl
@@ -1,0 +1,17 @@
+{{define "content"}}
+<article>
+    <h3>Highlight on Change</h3>
+    <p><small><code>lvt-fx:highlight="flash"</code> flashes a temporary background color whenever a render touches the element's subtree. Both displays below share the <em>same</em> counter — clicking Increment flashes <strong>both</strong>, demonstrating that the directive is per-element, not per-changed-value. Duration via <code>--lvt-highlight-duration</code> (default 500ms); color via <code>--lvt-highlight-color</code> (default amber <code>#ffc107</code>).</small></p>
+
+    <form method="POST">
+        <button name="increment">Increment</button>
+    </form>
+
+    <article lvt-fx:highlight="flash">
+        <p>Counter A: <strong>{{.Counter}}</strong></p>
+    </article>
+    <article lvt-fx:highlight="flash">
+        <p>Counter B (mirror): <strong>{{.Counter}}</strong></p>
+    </article>
+</article>
+{{end}}

--- a/patterns/templates/feedback/loading-states.tmpl
+++ b/patterns/templates/feedback/loading-states.tmpl
@@ -1,0 +1,45 @@
+{{define "content"}}
+<article>
+    <h3>Loading States</h3>
+    <p><small>Three layers of feedback during a slow action. All three forms call the same <code>slowSave</code> action (sleeps 2s server-side) so you can see the different presentations side by side.</small></p>
+
+    <section>
+        <h4>Tier 1 — Automatic</h4>
+        <p><small>The framework adds <code>aria-busy="true"</code> to the form and <code>disabled</code> to its <code>&lt;fieldset&gt;</code> while the action is in flight. No directives needed.</small></p>
+        <form method="POST">
+            <fieldset role="group">
+                <input name="data" placeholder="Type something…" aria-label="Tier 1 input">
+                <button name="slowSave">Save (2s)</button>
+            </fieldset>
+        </form>
+    </section>
+
+    <section>
+        <h4>Tier 2 — <code>lvt-form:disable-with</code></h4>
+        <p><small>Custom button text during pending. Restored when the action completes.</small></p>
+        <form method="POST">
+            <fieldset role="group">
+                <input name="data" placeholder="Type something…" aria-label="Tier 2a input">
+                <button name="slowSave" lvt-form:disable-with="Saving…">Save (2s)</button>
+            </fieldset>
+        </form>
+    </section>
+
+    <section>
+        <h4>Tier 2 — <code>lvt-el:setAttr</code> reactive attribute</h4>
+        <p><small>Toggle <code>aria-busy</code> via <code>:on:pending</code> / <code>:on:done</code>. Multi-action pages can scope this to a specific action (e.g. <code>:on:slowSave:pending</code>); leaving the action name out matches every action's lifecycle, which is fine here.</small></p>
+        <form method="POST">
+            <fieldset role="group">
+                <input name="data" placeholder="Type something…" aria-label="Tier 2b input">
+                <button name="slowSave"
+                    lvt-el:setAttr:on:pending="aria-busy:true"
+                    lvt-el:setAttr:on:done="aria-busy:false">Save (2s)</button>
+            </fieldset>
+        </form>
+    </section>
+
+    {{if .LastSave}}
+    <p><small>Last save: <strong>{{.LastSave}}</strong></small></p>
+    {{end}}
+</article>
+{{end}}

--- a/patterns/templates/feedback/loading-states.tmpl
+++ b/patterns/templates/feedback/loading-states.tmpl
@@ -38,6 +38,8 @@
         </form>
     </section>
 
+    {{/* All three sections call the same `slowSave` action, so this single
+         indicator updates regardless of which form was submitted. */}}
     {{if .LastSave}}
     <p><small>Last save: <strong>{{.LastSave}}</strong></small></p>
     {{end}}


### PR DESCRIPTION
## Summary

Implements Session 5 of the patterns example app per [`livetemplate/docs/proposals/patterns.md`](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/patterns.md). Adds 4 patterns under a new "Category 6: Visual Feedback":

- **#22 Animations** — `lvt-fx:animate="fade|slide|scale"` declarative entry animation. Mode select + Add Item button; new rows animate with the selected mode while existing rows are guarded by the WeakSet (one-shot per node lifetime).
- **#23 Loading States** — three-form demo:
  - Tier 1 automatic (`aria-busy` on form, `disabled` on fieldset)
  - Tier 2 `lvt-form:disable-with="Saving…"` (button text replacement)
  - Tier 2 `lvt-el:setAttr:on:pending="aria-busy:true"` + `:on:done="aria-busy:false"` (reactive attributes)

  All three call the same `slowSave` action with `time.Sleep(2*time.Second)`.
- **#24 Highlight on Change** — `lvt-fx:highlight="flash"` on two cards sharing a counter so users observe that every highlight target flashes on every render touching its subtree.
- **#25 Flash Messages / Toasts** — full `ctx.SetFlash` / `ctx.ClearFlash` / `FlashExpiry` lifecycle. Save (success with `FlashExpiry(5s)` or persistent error), Notify (persistent info, no expiry), Dismiss notify (`ClearFlash("info")`).

## Framework dependency bump

Bumps `go.mod` from `livetemplate v0.8.21` → **`v0.8.22`**, which carries the prune-before-render fix ([livetemplate/livetemplate#359](https://github.com/livetemplate/livetemplate/pull/359)). That fix was surfaced *by* this session's Flash Messages pattern: under v0.8.21, a 5-second auto-expiring flash actually stayed visible for one extra interaction past the deadline (prune ran after `sendUpdate` rather than before the next render's snapshot). With v0.8.22, the test verifies the demo's actual pitch: a single click after the deadline ships clean HTML.

## Test results

All 4 new tests pass standalone:
- `TestAnimations` — Initial_Load, Add_Plays_Fade_Animation, Mode_Switch_Affects_New_Rows, Existing_Rows_Do_Not_Re_animate, UI_Standards, Visual_Check
- `TestLoadingStates` — Initial_Load, Tier1_Fieldset_Disabled_During_Pending, DisableWith_Replaces_Button_Text, SetAttr_Pending_Sets_AriaBusy, Submit_Updates_LastSave, UI_Standards, Visual_Check
- `TestHighlightOnChange` — Initial_Load, Increment_Flashes_Both_Highlight_Targets, Highlight_Cleans_Up_After_Duration, Counter_Increments_On_Both_Mirrors, Visual_Check (UI_Standards intentionally skipped — pattern's premise is inline styles; see follow-up [livetemplate/client#100](https://github.com/livetemplate/client/issues/100))
- `TestFlashMessages` — Initial_Load, Empty_Save_Shows_Error_Flash, Valid_Save_Shows_Success_Clears_Error, Notify_Persists_Until_Dismiss, Success_AutoExpires_After_FlashExpiry, UI_Standards, Visual_Check

Pre-existing local Docker WS frame delay flakes (`TestDeleteRow`, `TestValueSelect`, `TestActiveSearch`, `TestLazyLoading`, `TestProgressBar`, `TestAsyncOperations`) reproduce on `main` — confirmed not Session 5–related.

## Test plan

- [x] `unset PORT && GOWORK=off go test -v -timeout=10m -run "TestAnimations|TestLoadingStates|TestHighlightOnChange|TestFlashMessages" ./patterns/` — all 4 pass standalone
- [x] `go vet ./patterns/...` — clean
- [x] `go build ./patterns/` — builds
- [x] `go.mod` updated to `livetemplate v0.8.22`
- [ ] Manual smoke check via `unset PORT && PORT=8765 GOWORK=off go run ./patterns` at http://devbox:8765 — exercise each new pattern in Chrome
- [ ] LLM visual checks: `LVT_VISUAL_CHECK=true GOWORK=off go test -v ./patterns -run "Visual_Check"`

## Out of scope / follow-ups

- `lvt-fx:highlight` leaves an empty `style=""` attribute after cleanup (animate's cleanup at `directives.ts:230-232` calls `removeAttribute('style')`; highlight should mirror). Filed as [livetemplate/client#100](https://github.com/livetemplate/client/issues/100). Worked around in this PR by skipping `UI_Standards` for the Highlight pattern (its premise is inline styling — the rule is not a meaningful guarantee for that page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)