### PR TITLE
feat: patterns example Session 7 — polish + README + final review

### DIFF
--- a/patterns/README.md
+++ b/patterns/README.md
@@ -1,0 +1,118 @@
+# LiveTemplate Patterns
+
+A catalog of 31 reactive UI patterns implemented with [LiveTemplate](https://github.com/livetemplate/livetemplate). Each pattern is a self-contained handler demonstrating a single idiom — forms, lists, navigation, real-time, and more.
+
+The patterns trace the [htmx examples](https://htmx.org/examples/) and [Phoenix LiveView patterns](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html), translated to LiveTemplate's controller + state model. Styled with [Pico CSS](https://picocss.com/).
+
+## Quick Start
+
+```bash
+cd examples
+GOWORK=off go run ./patterns
+```
+
+Open <http://localhost:8080> for the live index — every pattern links to its own page.
+
+```bash
+PORT=8081 GOWORK=off go run ./patterns
+```
+
+## What's Here
+
+### Forms & Editing
+
+- **Click To Edit** — toggle between view and edit mode
+- **Edit Row** — inline editing of table rows
+- **Inline Validation** — server-side field validation as you type
+- **Bulk Update** — batch checkbox operations
+- **Reset User Input** — auto-clear forms after submission
+- **File Upload** — standard and chunked file uploads
+- **Preserving File Inputs** — retain form values across re-renders
+
+### Lists & Data
+
+- **Delete Row** — animated row removal
+- **Click To Load** — append-only pagination
+- **Infinite Scroll** — auto-load on scroll with `lvt-scroll-sentinel`
+- **Value Select** — cascading dependent selects
+
+### Search & Filtering
+
+- **Active Search** — debounced live search
+- **URL-Preserved Filters** — bookmarkable filter state via query params
+
+### Loading & Progress
+
+- **Lazy Loading** — load content after page render via server push
+- **Progress Bar** — WebSocket-pushed progress updates
+- **Async Operations** — loading/success/error state machine
+
+### Dialogs, Tabs & Navigation
+
+- **Modal Dialog** — native dialog with `command`/`commandfor`
+- **Confirm Dialog** — CSP-compliant confirmation flow
+- **Tabs (HATEOAS)** — server-driven tabs via SPA navigation
+- **SPA Navigation** — auto link interception with pushState
+- **Keyboard Shortcuts** — global keyboard event binding
+
+### Visual Feedback
+
+- **Animations** — entry animations with `lvt-fx:animate`
+- **Loading States** — auto `aria-busy` and custom loading text
+- **Highlight on Change** — visual flash on DOM updates
+- **Flash Messages** — toast notifications via `ctx.SetFlash`
+
+### Real-Time & Multi-User
+
+- **Multi-User Sync** — auto-sync across tabs via `Sync()` handler
+- **Broadcasting** — cross-connection updates via `BroadcastAction`
+- **Presence Tracking** — explicit join/leave with shared state
+- **Reconnection Recovery** — state persistence via `lvt:"persist"`
+- **Live Preview** — real-time input preview via `Change()`
+- **Server Push** — background goroutine pushing updates with `session.TriggerAction`
+
+## Architecture
+
+One handler per pattern, grouped by category:
+
+```
+patterns/
+├── main.go                       # Mux wiring + index handler
+├── data.go                       # Sample data + pattern catalog (drives the index page)
+├── state_{category}.go           # State structs per category (Forms, Lists, …)
+├── handlers_{category}.go        # Controllers + action methods per category
+├── templates/
+│   ├── layout.tmpl               # Shared shell (Pico CSS, breadcrumb)
+│   ├── index.tmpl                # Catalog page rendered from data.go
+│   └── {category}/*.tmpl         # One template per pattern
+└── patterns_test.go              # E2E tests (chromedp)
+```
+
+Each pattern follows the [controller + state convention](https://github.com/livetemplate/livetemplate/blob/main/docs/references/controller-pattern.md): controllers are singletons holding dependencies; state is a plain struct cloned per session. Action methods have signature `func (c *Controller) Action(state State, ctx *Context) (State, error)`.
+
+The index page is data-driven by `data.go :: allPatterns()` — adding or renaming a pattern is a single struct edit.
+
+## Testing
+
+```bash
+# Full E2E suite (requires Docker for the chromedp container)
+unset PORT && GOWORK=off go test -v -race -timeout=10m ./patterns
+
+# Visual checks (LLM-validated screenshots, opt-in)
+unset PORT && LVT_VISUAL_CHECK=true GOWORK=off go test -v ./patterns -run "Visual_Check"
+
+# Single pattern
+GOWORK=off go test -v ./patterns -run TestEditRow
+```
+
+Multi-tab tests (`TestMultiUserSync`, `TestBroadcasting`, `TestPresence`) use `chromedp.NewContext(parentCtx)` to open a second tab on the same allocator, sharing the session-group cookie. See `setupPeerTab` in `patterns_test.go`.
+
+E2E tests have access to browser console logs, server logs, WebSocket messages, and rendered HTML — see [`livetemplate/CLAUDE.md`](https://github.com/livetemplate/livetemplate/blob/main/CLAUDE.md) for the full E2E contract.
+
+## Reference
+
+- [`docs/proposals/patterns.md`](https://github.com/livetemplate/livetemplate/blob/main/docs/proposals/patterns.md) — original proposal driving the implementation
+- [`examples/CLAUDE.md`](../CLAUDE.md) — examples-repo conventions (Tier 1 vs Tier 2, Pico/CSP boilerplate)
+- [`livetemplate/CLAUDE.md`](https://github.com/livetemplate/livetemplate/blob/main/CLAUDE.md) — controller pattern, `data-key`, AI review loop
+- [Progressive Complexity Reference](https://github.com/livetemplate/livetemplate/blob/main/docs/references/progressive-complexity-reference.md) — Tier 1 vs Tier 2
+- [Client Attributes Reference](https://github.com/livetemplate/livetemplate/blob/main/docs/references/client-attributes.md) — `lvt-*` attribute listing

--- a/patterns/handlers_feedback.go
+++ b/patterns/handlers_feedback.go
@@ -91,6 +91,24 @@ type FlashMessagesController struct{}
 
 const flashSuccessExpiry = 5 * time.Second
 
+// nudgeFlashExpiry triggers a re-render at FlashExpiry's deadline.
+// FlashExpiry is render-driven (no background timer), so without a nudge
+// the expired flash sits in the DOM until the user's next interaction.
+// The pruner runs on the next render and removes the expired entry.
+//
+// The "refresh" action it dispatches is registered as a no-op handler on
+// each controller that calls this helper.
+func nudgeFlashExpiry(ctx *livetemplate.Context, expiry time.Duration) {
+	session := ctx.Session()
+	if session == nil {
+		return
+	}
+	go func() {
+		time.Sleep(expiry + 100*time.Millisecond)
+		_ = session.TriggerAction("refresh", nil)
+	}()
+}
+
 func (c *FlashMessagesController) Save(state FlashMessagesState, ctx *livetemplate.Context) (FlashMessagesState, error) {
 	name := strings.TrimSpace(ctx.GetString("name"))
 	if name == "" {
@@ -100,18 +118,7 @@ func (c *FlashMessagesController) Save(state FlashMessagesState, ctx *livetempla
 	}
 	ctx.ClearFlash("error")
 	ctx.SetFlash("success", "Saved: "+name, livetemplate.FlashExpiry(flashSuccessExpiry))
-
-	// FlashExpiry is render-driven (no background timer), so without a
-	// nudge the success flash would only disappear when the user next
-	// interacts. Schedule a server-side wake-up that triggers a re-render
-	// at the deadline; getMessages prunes the expired entry before
-	// snapshotting and the client sees the flash disappear on its own.
-	if session := ctx.Session(); session != nil {
-		go func() {
-			time.Sleep(flashSuccessExpiry + 100*time.Millisecond)
-			_ = session.TriggerAction("refresh", nil)
-		}()
-	}
+	nudgeFlashExpiry(ctx, flashSuccessExpiry)
 	return state, nil
 }
 

--- a/patterns/handlers_forms.go
+++ b/patterns/handlers_forms.go
@@ -186,7 +186,7 @@ func (c *FileUploadController) Upload(state FileUploadState, ctx *livetemplate.C
 		if ctx.HasUploads(name) {
 			entries := ctx.GetCompletedUploads(name)
 			if len(entries) > 0 {
-				ctx.SetFlash("success", "Uploaded: "+entries[0].ClientName)
+				ctx.SetFlash("success", "Uploaded: "+entries[0].ClientName, livetemplate.FlashExpiry(flashSuccessExpiry))
 				return state, nil
 			}
 		}
@@ -225,7 +225,7 @@ func (c *PreserveInputsController) Submit(state PreserveInputsState, ctx *livete
 	if err := ctx.ValidateForm(); err != nil {
 		return state, err
 	}
-	ctx.SetFlash("success", "Saved: "+state.Name)
+	ctx.SetFlash("success", "Saved: "+state.Name, livetemplate.FlashExpiry(flashSuccessExpiry))
 	return state, nil
 }
 

--- a/patterns/handlers_forms.go
+++ b/patterns/handlers_forms.go
@@ -187,11 +187,16 @@ func (c *FileUploadController) Upload(state FileUploadState, ctx *livetemplate.C
 			entries := ctx.GetCompletedUploads(name)
 			if len(entries) > 0 {
 				ctx.SetFlash("success", "Uploaded: "+entries[0].ClientName, livetemplate.FlashExpiry(flashSuccessExpiry))
+				nudgeFlashExpiry(ctx, flashSuccessExpiry)
 				return state, nil
 			}
 		}
 	}
 	ctx.SetFlash("error", "No file selected")
+	return state, nil
+}
+
+func (c *FileUploadController) Refresh(state FileUploadState, ctx *livetemplate.Context) (FileUploadState, error) {
 	return state, nil
 }
 
@@ -226,6 +231,11 @@ func (c *PreserveInputsController) Submit(state PreserveInputsState, ctx *livete
 		return state, err
 	}
 	ctx.SetFlash("success", "Saved: "+state.Name, livetemplate.FlashExpiry(flashSuccessExpiry))
+	nudgeFlashExpiry(ctx, flashSuccessExpiry)
+	return state, nil
+}
+
+func (c *PreserveInputsController) Refresh(state PreserveInputsState, ctx *livetemplate.Context) (PreserveInputsState, error) {
 	return state, nil
 }
 

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -186,7 +186,7 @@ func (c *ProgressBarController) UpdateProgress(state ProgressBarState, ctx *live
 	if state.Progress >= 100 {
 		state.Running = false
 		state.Done = true
-		ctx.SetFlash("success", "Job complete")
+		ctx.SetFlash("success", "Job complete", livetemplate.FlashExpiry(flashSuccessExpiry))
 	}
 	return state, nil
 }
@@ -282,7 +282,7 @@ func (c *AsyncOpsController) FetchResult(state AsyncOpsState, ctx *livetemplate.
 		state.Status = "success"
 		state.Result = ctx.GetString("result")
 		state.Error = ""
-		ctx.SetFlash("success", "Fetch complete")
+		ctx.SetFlash("success", "Fetch complete", livetemplate.FlashExpiry(flashSuccessExpiry))
 	} else {
 		state.Status = "error"
 		state.Error = ctx.GetString("error")

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -130,12 +130,15 @@ func lazyLoadingHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // ProgressBarController drives a bounded goroutine that ticks progress from
 // 10% to 100% in 10% increments every 500ms. session.TriggerAction is
-// retried for ~5 seconds when the session group has zero connections, so
-// brief mobile backgrounding (iOS app-switch under the client's 3s
-// visibility-reconnect threshold) doesn't lose ticks. After the retry
-// window expires, the goroutine exits — the next Mount returns
-// non-Running state (Running is intentionally not persisted) and the
-// user sees a clean Start Job button.
+// retried for ~5 seconds per tick when the session group has zero
+// connections, so brief mobile backgrounding (iOS app-switch under the
+// client's 3s visibility-reconnect threshold) doesn't lose ticks. The
+// retry budget is per-tick — a tick that never succeeds blocks for ~5s,
+// so the goroutine's worst-case lifetime under a permanent disconnect is
+// progressRetryWindow × ceil((100-Progress)/progressStep), bounded at
+// ~50s for the full 10-tick run. The next Mount returns non-Running
+// state (Running is intentionally not persisted) and the user sees a
+// clean Start Job button.
 //
 // No Mount-driven revival: a second goroutine spawned by Mount while the
 // retrying goroutine was still alive caused racing UpdateProgress writes

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -129,38 +129,32 @@ func lazyLoadingHandler(baseOpts []livetemplate.Option) http.Handler {
 // --- Pattern #15: Progress Bar ---
 
 // ProgressBarController drives a bounded goroutine that ticks progress from
-// 10% to 100% in 10% increments every 500ms. The goroutine exits cleanly if
-// session.TriggerAction returns an error (session disconnected) — this is the
-// canonical cancellation pattern documented in the Server Push pattern (#31).
+// 10% to 100% in 10% increments every 500ms. session.TriggerAction is
+// retried for ~5 seconds when the session group has zero connections, so
+// brief mobile backgrounding (iOS app-switch under the client's 3s
+// visibility-reconnect threshold) doesn't lose ticks. After the retry
+// window expires, the goroutine exits — the next Mount returns
+// non-Running state (Running is intentionally not persisted) and the
+// user sees a clean Start Job button.
 //
-// Reconnect semantics — why no OnConnect:
-// ProgressBarState has no `lvt:"persist"` struct tags, so `h.persistable == nil`
-// in the framework and `restorePersistedState` returns (nil, false). On every
-// WebSocket connect (including reconnects after a network blip), mount.go falls
-// through to `cloneStateTyped()` and produces fresh zero-value state
-// (Running=false, Done=false, Progress=0). The "stuck Running=true with no
-// goroutine" scenario therefore cannot occur — reconnecting always shows the
-// Start button again. LazyLoadController needs OnConnect because the spinner
-// vs. data swap is the *whole point* of that pattern; here the pattern is the
-// goroutine ticking the bar, and a mid-run disconnect simply ends that demo
-// (the user clicks Start again on the next page load).
+// No Mount-driven revival: a second goroutine spawned by Mount while the
+// retrying goroutine was still alive caused racing UpdateProgress writes
+// (one goroutine sets Done=true, the trailing one overwrites Progress
+// with a mid-flight value, producing impossible "Run Again at 70%" UI).
+// UpdateProgress also guards on state.Done as defense in depth.
 type ProgressBarController struct{}
 
 const (
-	progressStep     = 10
-	progressTickRate = 500 * time.Millisecond
+	progressStep         = 10
+	progressTickRate     = 500 * time.Millisecond
+	progressRetryDelay   = 100 * time.Millisecond
+	progressRetryBudget  = 50 // 50 × 100ms = 5s
 )
 
 func (c *ProgressBarController) Start(state ProgressBarState, ctx *livetemplate.Context) (ProgressBarState, error) {
-	// Per-session guard against double-click stacking two goroutines.
 	if state.Running {
 		return state, nil
 	}
-	// Check session BEFORE setting Running=true. With livetemplate v0.8.18+
-	// this is always non-nil, but if it ever became nil the previous
-	// ordering (mutate first, check second) would leave Running=true
-	// permanently and the Running guard above would block all subsequent
-	// Start clicks. Checking first ensures the UI stays interactive.
 	session := ctx.Session()
 	if session == nil {
 		return state, nil
@@ -168,27 +162,60 @@ func (c *ProgressBarController) Start(state ProgressBarState, ctx *livetemplate.
 	state.Running = true
 	state.Done = false
 	state.Progress = 0
-	go func() {
-		for i := progressStep; i <= 100; i += progressStep {
-			time.Sleep(progressTickRate)
-			if err := session.TriggerAction("updateProgress", map[string]any{
-				"progress": i,
-			}); err != nil {
-				return // Session disconnected — stop cleanly.
-			}
-		}
-	}()
+	c.spawnTicker(session)
 	return state, nil
 }
 
 func (c *ProgressBarController) UpdateProgress(state ProgressBarState, ctx *livetemplate.Context) (ProgressBarState, error) {
+	// Guard against stale ticks from a goroutine that was overtaken by a
+	// faster one (e.g. multi-tab race). Without this, a trailing goroutine
+	// could overwrite Progress to a mid-flight value AFTER another goroutine
+	// already set Done=true, producing an impossible "Run Again at 70%" UI.
+	if state.Done {
+		return state, nil
+	}
 	state.Progress = ctx.GetInt("progress")
 	if state.Progress >= 100 {
 		state.Running = false
 		state.Done = true
 		ctx.SetFlash("success", "Job complete", livetemplate.FlashExpiry(flashSuccessExpiry))
+		nudgeFlashExpiry(ctx, flashSuccessExpiry)
 	}
 	return state, nil
+}
+
+func (c *ProgressBarController) Refresh(state ProgressBarState, ctx *livetemplate.Context) (ProgressBarState, error) {
+	return state, nil
+}
+
+// spawnTicker drives state.Progress 10..100. tickWithRetry survives a
+// ~5s window of dead WebSocket so brief mobile backgrounds don't end
+// the run; if the connection comes back within that window the timer
+// resumes seamlessly.
+func (c *ProgressBarController) spawnTicker(session livetemplate.Session) {
+	go func() {
+		for i := progressStep; i <= 100; i += progressStep {
+			time.Sleep(progressTickRate)
+			if err := tickWithRetry(session, i); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func tickWithRetry(session livetemplate.Session, progress int) error {
+	var lastErr error
+	for attempt := 0; attempt < progressRetryBudget; attempt++ {
+		if err := session.TriggerAction("updateProgress", map[string]any{
+			"progress": progress,
+		}); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(progressRetryDelay)
+	}
+	return lastErr
 }
 
 func progressBarHandler(baseOpts []livetemplate.Option) http.Handler {
@@ -283,12 +310,17 @@ func (c *AsyncOpsController) FetchResult(state AsyncOpsState, ctx *livetemplate.
 		state.Result = ctx.GetString("result")
 		state.Error = ""
 		ctx.SetFlash("success", "Fetch complete", livetemplate.FlashExpiry(flashSuccessExpiry))
+		nudgeFlashExpiry(ctx, flashSuccessExpiry)
 	} else {
 		state.Status = "error"
 		state.Error = ctx.GetString("error")
 		state.Result = ""
 		ctx.SetFlash("error", "Fetch failed")
 	}
+	return state, nil
+}
+
+func (c *AsyncOpsController) Refresh(state AsyncOpsState, ctx *livetemplate.Context) (AsyncOpsState, error) {
 	return state, nil
 }
 

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -218,6 +218,9 @@ func (c *ProgressBarController) spawnTicker(session livetemplate.Session) {
 func tickWithRetry(session livetemplate.Session, progress int) error {
 	var lastErr error
 	for attempt := 0; attempt < progressRetryAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(progressRetryDelay)
+		}
 		if err := session.TriggerAction("updateProgress", map[string]any{
 			"progress": progress,
 		}); err == nil {
@@ -225,7 +228,6 @@ func tickWithRetry(session livetemplate.Session, progress int) error {
 		} else {
 			lastErr = err
 		}
-		time.Sleep(progressRetryDelay)
 	}
 	return lastErr
 }

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -135,8 +135,8 @@ func lazyLoadingHandler(baseOpts []livetemplate.Option) http.Handler {
 // client's 3s visibility-reconnect threshold) doesn't lose ticks. The
 // retry budget is per-tick — a tick that never succeeds blocks for ~5s,
 // so the goroutine's worst-case lifetime under a permanent disconnect is
-// progressRetryWindow × ceil((100-Progress)/progressStep), bounded at
-// ~50s for the full 10-tick run. The next Mount returns non-Running
+// (progressTickRate + progressRetryWindow) × ceil((100-Progress)/progressStep),
+// bounded at ~55s for the full 10-tick run. The next Mount returns non-Running
 // state (Running is intentionally not persisted) and the user sees a
 // clean Start Job button.
 //
@@ -152,16 +152,18 @@ func lazyLoadingHandler(baseOpts []livetemplate.Option) http.Handler {
 // UpdateProgress also guards on state.Done as defense in depth.
 type ProgressBarController struct{}
 
+// Retry attempt count derives from window/delay so the ~5s total stays
+// consistent if either is tuned later. Both Duration operands are
+// constants and Go allows int(typedConst), so the whole trio remains
+// const — keeps the values immutable from test code.
 const (
 	progressStep        = 10
 	progressTickRate    = 500 * time.Millisecond
 	progressRetryDelay  = 100 * time.Millisecond
 	progressRetryWindow = 5 * time.Second
-)
 
-// progressRetryAttempts derives directly from the window/delay so the
-// "5s total" promise stays consistent if either is tuned later.
-var progressRetryAttempts = int(progressRetryWindow / progressRetryDelay)
+	progressRetryAttempts = int(progressRetryWindow / progressRetryDelay)
+)
 
 func (c *ProgressBarController) Start(state ProgressBarState, ctx *livetemplate.Context) (ProgressBarState, error) {
 	if state.Running {
@@ -221,13 +223,13 @@ func tickWithRetry(session livetemplate.Session, progress int) error {
 		if attempt > 0 {
 			time.Sleep(progressRetryDelay)
 		}
-		if err := session.TriggerAction("updateProgress", map[string]any{
+		err := session.TriggerAction("updateProgress", map[string]any{
 			"progress": progress,
-		}); err == nil {
+		})
+		if err == nil {
 			return nil
-		} else {
-			lastErr = err
 		}
+		lastErr = err
 	}
 	return lastErr
 }

--- a/patterns/handlers_loading.go
+++ b/patterns/handlers_loading.go
@@ -141,15 +141,24 @@ func lazyLoadingHandler(baseOpts []livetemplate.Option) http.Handler {
 // retrying goroutine was still alive caused racing UpdateProgress writes
 // (one goroutine sets Done=true, the trailing one overwrites Progress
 // with a mid-flight value, producing impossible "Run Again at 70%" UI).
+// Likewise no OnConnect: the framework's restorePersistedState already
+// loads Progress/Done from the session-group store on every reconnect,
+// so manual hydration would be redundant and would re-introduce the
+// same race window.
+//
 // UpdateProgress also guards on state.Done as defense in depth.
 type ProgressBarController struct{}
 
 const (
-	progressStep         = 10
-	progressTickRate     = 500 * time.Millisecond
-	progressRetryDelay   = 100 * time.Millisecond
-	progressRetryBudget  = 50 // 50 × 100ms = 5s
+	progressStep        = 10
+	progressTickRate    = 500 * time.Millisecond
+	progressRetryDelay  = 100 * time.Millisecond
+	progressRetryWindow = 5 * time.Second
 )
+
+// progressRetryAttempts derives directly from the window/delay so the
+// "5s total" promise stays consistent if either is tuned later.
+var progressRetryAttempts = int(progressRetryWindow / progressRetryDelay)
 
 func (c *ProgressBarController) Start(state ProgressBarState, ctx *livetemplate.Context) (ProgressBarState, error) {
 	if state.Running {
@@ -205,7 +214,7 @@ func (c *ProgressBarController) spawnTicker(session livetemplate.Session) {
 
 func tickWithRetry(session livetemplate.Session, progress int) error {
 	var lastErr error
-	for attempt := 0; attempt < progressRetryBudget; attempt++ {
+	for attempt := 0; attempt < progressRetryAttempts; attempt++ {
 		if err := session.TriggerAction("updateProgress", map[string]any{
 			"progress": progress,
 		}); err == nil {

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -30,7 +30,6 @@ func indexHandler(baseOpts []livetemplate.Option) http.Handler {
 	)
 	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
 	return tmpl.Handle(&IndexController{}, livetemplate.AsState(&IndexState{
-		Title:      "LiveTemplate Patterns",
 		Categories: allPatterns(),
 	}))
 }

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1623,7 +1623,11 @@ func TestProgressBar(t *testing.T) {
 			// visibility-reconnect path uses, so the server treats it
 			// identically to an iOS-killed connection.
 			chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
-			// Reconnect within ~1s — well inside the 5s retry budget.
+			// Wall-clock sleep: we're deliberately leaving the connection
+			// down inside the goroutine's 5s retry window to verify it
+			// survives the gap. There's no client-observable signal
+			// during the retry loop (the goroutine's TriggerAction errors
+			// silently), so a condition-based wait wouldn't fit here.
 			chromedp.Sleep(1*time.Second),
 			chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
 			e2etest.WaitForWebSocketReady(5*time.Second),

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1607,6 +1607,190 @@ func TestProgressBar(t *testing.T) {
 		}
 	})
 
+	t.Run("Brief_Disconnect_Within_Retry_Window_Completes", func(t *testing.T) {
+		// Reload to clean state. Click Start. Once the timer is mid-flight,
+		// force-disconnect the WebSocket via the client's public API. The
+		// server-side ticker will retry session.TriggerAction for ~5s; if we
+		// reconnect within that window, the timer must continue and
+		// complete to 100%.
+		err := chromedp.Run(ctx,
+			chromedp.Reload(),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="start"]`, chromedp.ByQuery),
+			chromedp.Click(`button[name="start"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('progress') && document.querySelector('progress').value >= 20`, 3*time.Second),
+			// Force-disconnect; this is the same disconnect() the
+			// visibility-reconnect path uses, so the server treats it
+			// identically to an iOS-killed connection.
+			chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
+			// Reconnect within ~1s — well inside the 5s retry budget.
+			chromedp.Sleep(1*time.Second),
+			chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			// Run continues. Wait for completion.
+			e2etest.WaitForText(`button`, "Run Again", 10*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Brief-disconnect run did not complete: %v", err)
+		}
+	})
+
+	t.Run("Long_Disconnect_Beyond_Retry_Window_Settles_Without_Impossible_State", func(t *testing.T) {
+		// Reload to clean state. Click Start. Mid-flight, disconnect for
+		// 7s — past the goroutine's 5s retry budget. The goroutine must
+		// give up; on reconnect the page must NOT display a corrupted
+		// state (Done=true with Progress<100, or Running=true with no
+		// goroutine to advance it). Acceptable settled states: clean
+		// "Start Job" button (Running=false, Done=false) OR completed
+		// "Run Again" with Progress=100.
+		err := chromedp.Run(ctx,
+			chromedp.Reload(),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="start"]`, chromedp.ByQuery),
+			chromedp.Click(`button[name="start"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('progress') && document.querySelector('progress').value >= 20`, 3*time.Second),
+			chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
+			// chromedp.Sleep is intentional — we're waiting wall-clock
+			// for the goroutine's 5s retry budget to expire.
+			chromedp.Sleep(7*time.Second),
+			chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			// Wait for a stable settled state.
+			e2etest.WaitFor(`(() => {
+				const btn = document.querySelector('button[name="start"]');
+				if (!btn) return false;
+				return btn.textContent.includes('Start Job') || btn.textContent.includes('Run Again');
+			})()`, 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Long-disconnect run did not settle: %v", err)
+		}
+
+		// Invariant: if "Run Again" is shown (Done=true), progress must be 100.
+		// If "Start Job" is shown (Running=false, Done=false), no progress
+		// element should be present.
+		var settled struct {
+			HasRunAgain bool `json:"hasRunAgain"`
+			HasStartJob bool `json:"hasStartJob"`
+			HasProgress bool `json:"hasProgress"`
+			ProgressVal int  `json:"progressVal"`
+		}
+		err = chromedp.Run(ctx, chromedp.Evaluate(`(() => {
+			const btn = document.querySelector('button[name="start"]');
+			const p = document.querySelector('progress');
+			return {
+				hasRunAgain: btn && btn.textContent.includes('Run Again'),
+				hasStartJob: btn && btn.textContent.includes('Start Job'),
+				hasProgress: !!p,
+				progressVal: p ? Number(p.value) : 0,
+			};
+		})()`, &settled))
+		if err != nil {
+			t.Fatalf("Could not read settled state: %v", err)
+		}
+		if settled.HasRunAgain && settled.ProgressVal != 100 {
+			t.Errorf("Impossible state: Run Again button shown but progress=%d (must be 100)", settled.ProgressVal)
+		}
+		if settled.HasStartJob && settled.HasProgress {
+			t.Errorf("Impossible state: Start Job button shown but progress element still present")
+		}
+		if !settled.HasRunAgain && !settled.HasStartJob {
+			t.Error("Impossible state: neither Run Again nor Start Job button shown after long disconnect")
+		}
+	})
+
+	t.Run("Multiple_Disconnect_Cycles_Never_Produce_Impossible_State", func(t *testing.T) {
+		// Run Again, then disconnect/reconnect rapidly several times during
+		// the run. After settled, verify the same invariant: Done=true →
+		// Progress=100. This is the regression test for the bug where Mount
+		// revival spawned a competing goroutine that overwrote Progress with
+		// a stale value AFTER another goroutine had set Done=true.
+		err := chromedp.Run(ctx,
+			chromedp.Reload(),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="start"]`, chromedp.ByQuery),
+			chromedp.Click(`button[name="start"]`, chromedp.ByQuery),
+			e2etest.WaitFor(`document.querySelector('progress') && document.querySelector('progress').value >= 10`, 3*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Could not start the timer: %v", err)
+		}
+
+		// Three disconnect/reconnect cycles, each ~700ms. Within retry
+		// budget so the goroutine stays alive across them.
+		for i := 0; i < 3; i++ {
+			err := chromedp.Run(ctx,
+				chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
+				chromedp.Sleep(300*time.Millisecond),
+				chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+				e2etest.WaitForWebSocketReady(3*time.Second),
+				chromedp.Sleep(400*time.Millisecond),
+			)
+			if err != nil {
+				t.Fatalf("Disconnect cycle %d failed: %v", i, err)
+			}
+		}
+
+		// Wait for a stable final state.
+		err = chromedp.Run(ctx,
+			e2etest.WaitFor(`(() => {
+				const btn = document.querySelector('button[name="start"]');
+				if (!btn) return false;
+				return btn.textContent.includes('Start Job') || btn.textContent.includes('Run Again');
+			})()`, 15*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Did not settle after disconnect cycles: %v", err)
+		}
+
+		var settled struct {
+			HasRunAgain bool `json:"hasRunAgain"`
+			HasStartJob bool `json:"hasStartJob"`
+			ProgressVal int  `json:"progressVal"`
+		}
+		err = chromedp.Run(ctx, chromedp.Evaluate(`(() => {
+			const btn = document.querySelector('button[name="start"]');
+			const p = document.querySelector('progress');
+			return {
+				hasRunAgain: btn && btn.textContent.includes('Run Again'),
+				hasStartJob: btn && btn.textContent.includes('Start Job'),
+				progressVal: p ? Number(p.value) : 0,
+			};
+		})()`, &settled))
+		if err != nil {
+			t.Fatalf("Could not read settled state: %v", err)
+		}
+		// The core invariant: if the UI advertises completion (Run Again
+		// button), progress must be a true 100. The screenshot reproducer
+		// for this bug showed Run Again next to a 70% bar.
+		if settled.HasRunAgain && settled.ProgressVal != 100 {
+			t.Errorf("Impossible state after disconnect cycles: Run Again button shown but progress=%d", settled.ProgressVal)
+		}
+	})
+
+	t.Run("Done_State_Survives_Reconnect_Via_Persist", func(t *testing.T) {
+		// Progress and Done are lvt:"persist" — a completed run must stay
+		// completed across a disconnect/reconnect cycle. The user keeps the
+		// "Run Again" button rather than snapping back to Start Job.
+		err := chromedp.Run(ctx,
+			chromedp.Reload(),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`button[name="start"]`, chromedp.ByQuery),
+			chromedp.Click(`button[name="start"]`, chromedp.ByQuery),
+			e2etest.WaitForText(`button`, "Run Again", 10*time.Second),
+			// Disconnect/reconnect after completion.
+			chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
+			chromedp.Sleep(500*time.Millisecond),
+			chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			// Run Again must still be there.
+			e2etest.WaitForText(`button`, "Run Again", 5*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Done state did not persist across reconnect: %v", err)
+		}
+	})
+
 	runStandardSubtests(t, ctx, false, "Progress Bar — completed state showing a full progress bar, a 'Job complete' success flash below it, and a 'Run Again' button")
 }
 

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1716,15 +1716,29 @@ func TestProgressBar(t *testing.T) {
 			t.Fatalf("Could not start the timer: %v", err)
 		}
 
-		// Three disconnect/reconnect cycles, each ~700ms. Within retry
-		// budget so the goroutine stays alive across them.
+		// Three disconnect/reconnect cycles. Each cycle: capture progress
+		// before, fire disconnect+connect back-to-back, wait for the
+		// reconnect to land, then wait for the goroutine to make further
+		// progress (or for the run to complete) before the next cycle —
+		// avoids fixed-duration sleeps that flake on slow CI.
 		for i := 0; i < 3; i++ {
-			err := chromedp.Run(ctx,
-				chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
-				chromedp.Sleep(300*time.Millisecond),
-				chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+			var beforeProgress int
+			err := chromedp.Run(ctx, chromedp.Evaluate(
+				`(()=>{const p=document.querySelector('progress');return p?Number(p.value):0;})()`,
+				&beforeProgress,
+			))
+			if err != nil {
+				t.Fatalf("Cycle %d: could not read pre-cycle progress: %v", i, err)
+			}
+			err = chromedp.Run(ctx,
+				chromedp.Evaluate(`window.liveTemplateClient.disconnect(); window.liveTemplateClient.connect()`, nil),
 				e2etest.WaitForWebSocketReady(3*time.Second),
-				chromedp.Sleep(400*time.Millisecond),
+				e2etest.WaitFor(fmt.Sprintf(`(() => {
+					const btn = document.querySelector('button[name="start"]');
+					if (btn && btn.textContent.includes('Run Again')) return true;
+					const p = document.querySelector('progress');
+					return p && Number(p.value) > %d;
+				})()`, beforeProgress), 5*time.Second),
 			)
 			if err != nil {
 				t.Fatalf("Disconnect cycle %d failed: %v", i, err)
@@ -1778,10 +1792,9 @@ func TestProgressBar(t *testing.T) {
 			chromedp.WaitVisible(`button[name="start"]`, chromedp.ByQuery),
 			chromedp.Click(`button[name="start"]`, chromedp.ByQuery),
 			e2etest.WaitForText(`button`, "Run Again", 10*time.Second),
-			// Disconnect/reconnect after completion.
-			chromedp.Evaluate(`window.liveTemplateClient.disconnect()`, nil),
-			chromedp.Sleep(500*time.Millisecond),
-			chromedp.Evaluate(`window.liveTemplateClient.connect()`, nil),
+			// Disconnect+reconnect back-to-back; WaitForWebSocketReady
+			// synchronises on the new connection rather than a fixed sleep.
+			chromedp.Evaluate(`window.liveTemplateClient.disconnect(); window.liveTemplateClient.connect()`, nil),
 			e2etest.WaitForWebSocketReady(5*time.Second),
 			// Run Again must still be there.
 			e2etest.WaitForText(`button`, "Run Again", 5*time.Second),

--- a/patterns/state_loading.go
+++ b/patterns/state_loading.go
@@ -9,12 +9,22 @@ type LazyLoadState struct {
 }
 
 // ProgressBarState holds the state for the Progress Bar pattern (#15).
+//
+// Progress and Done are persisted so a completed run's outcome
+// survives a brief reconnect (e.g. mobile app-switching). Running is
+// NOT persisted: a stale Running=true with no goroutine to advance it
+// would leave the UI on aria-busy forever, the failure mode Pattern
+// #31 explicitly avoids. The ticker goroutine retries TriggerAction
+// for a bounded window before exiting, so brief backgrounds (<~5s)
+// are recovered by the goroutine itself; longer disconnects exit and
+// the user sees a clean "Start Job" button via the persisted but
+// non-Running state.
 type ProgressBarState struct {
 	Title    string
 	Category string
-	Progress int
+	Progress int `lvt:"persist"`
 	Running  bool
-	Done     bool
+	Done     bool `lvt:"persist"`
 }
 
 // AsyncOpsState holds the state for the Async Operations pattern (#16).

--- a/patterns/templates/forms/bulk-update.tmpl
+++ b/patterns/templates/forms/bulk-update.tmpl
@@ -9,7 +9,7 @@
             <tr data-key="{{.ID}}">
                 <td>{{.Name}}</td>
                 <td>{{.Email}}</td>
-                <td><input type="checkbox" name="active-{{.ID}}" {{if .Active}}checked{{end}}></td>
+                <td><input type="checkbox" name="active-{{.ID}}" aria-label="Active for {{.Name}}" {{if .Active}}checked{{end}}></td>
             </tr>
             {{end}}
             </tbody>

--- a/patterns/templates/forms/edit-row.tmpl
+++ b/patterns/templates/forms/edit-row.tmpl
@@ -10,8 +10,8 @@
             <td colspan="3">
                 <form method="POST" class="inline">
                     <fieldset role="group">
-                        <input name="name" value="{{.Name}}">
-                        <input name="email" value="{{.Email}}">
+                        <input name="name" value="{{.Name}}" aria-label="Name">
+                        <input name="email" value="{{.Email}}" aria-label="Email">
                         <button name="save" value="{{.ID}}" class="compact">Save</button>
                         <button name="cancel" class="compact secondary">Cancel</button>
                     </fieldset>

--- a/patterns/templates/forms/reset-input.tmpl
+++ b/patterns/templates/forms/reset-input.tmpl
@@ -4,7 +4,7 @@
     <p><small>Form clears automatically after successful submission — no extra attributes needed.</small></p>
     <form method="POST">
         <fieldset role="group">
-            <input name="message" placeholder="Type a message..." required>
+            <input name="message" placeholder="Type a message..." aria-label="Message" required>
             <button type="submit">Send</button>
         </fieldset>
     </form>

--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark">
-    <title>{{.Title}} — LiveTemplate Patterns</title>
+    <title>{{if .Title}}{{.Title}} — {{end}}LiveTemplate Patterns</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     {{if .lvt.DevMode}}
     <link rel="stylesheet" href="/livetemplate.css">


### PR DESCRIPTION
## Summary

Session 7 (the final session in the patterns proposal) — polish, README, follow-up resolution, and iOS reconnect resilience.

- **README** for the patterns example (`patterns/README.md`): quick-start, 31-pattern catalog by category, architecture pointer, testing instructions.
- **Closes Session 1 follow-ups #62-#65**: double-title fix on the index page (conditional layout `<title>`), aria-labels on edit-row inputs, reset-input message field, and bulk-update per-row checkboxes. (#66 was already wrapped in a form in a prior session; #67/#68 already use condition-based waits.)
- **SetFlash audit**: success flashes in #6 (File Upload), #7 (Preserving File Inputs), #15 (Progress Bar), #16 (Async Operations) now auto-expire after 5s via `FlashExpiry` + a new `nudgeFlashExpiry` helper that schedules a follow-up render at the deadline. Errors stay sticky.
- **Pattern #15 Progress Bar — iPhone resilience**: the timer now survives mobile app-switching. Goroutine retries TriggerAction for ~5s on dead-connection windows; `Progress`/`Done` are persisted so completed runs survive reconnect. `Running` is intentionally not persisted (same trade-off as Pattern #31 — avoids "stuck Running=true with no goroutine" UI). `UpdateProgress` guards on `state.Done` to drop stale ticks from any race. Four new chromedp tests cover the disconnect scenarios.
- **Drag-and-drop and `lvt-scroll-away` top-edge** filed as client-repo follow-ups: [livetemplate/client#101](https://github.com/livetemplate/client/issues/101), [livetemplate/client#102](https://github.com/livetemplate/client/issues/102).

## Companion changes

- `livetemplate/client` PR #99 merged → **client v0.8.35** released to npm. Adds `visibilitychange`/`pageshow`-driven reconnect with iOS zombie-socket defense. The patterns templates use `@latest` from CDN, so the iOS fix is already live.

## Test plan

- [x] `./test-all.sh` — all 12 examples green
- [x] `go test -v -race -timeout=10m ./patterns` — full suite passes (213s)
- [x] Manual iPhone Safari review — Pattern #15 timer resumes through app-switching, no impossible "Run Again at N%" UI
- [ ] AI review loop converges
- [ ] Reviewer signoff

## Out of scope

- Sortable/drag-and-drop pattern (filed-as-issue, not implemented)
- Cross-instance PubSub for Session 6 patterns
- New library/client features beyond what surfaced as bugs (the v0.8.35 fix landed upstream first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)