### PR TITLE
docs(patterns): record client v0.8.37 cleanup in highlight UI_Standards comment

### DIFF
--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -2674,14 +2674,14 @@ func TestHighlightOnChange(t *testing.T) {
 	// UI_Standards is intentionally NOT run for this pattern. The highlight
 	// directive's whole job is to add an inline background-color and
 	// transition for the visual flash, which fires on every render walk that
-	// touches the subtree — including the first paint. After cleanup,
-	// directives.ts leaves an empty `style=""` attribute (animate's cleanup
-	// at directives.ts:230-232 calls `removeAttribute('style')`; highlight
-	// does not). The "no inline styles" rule isn't a meaningful guarantee
-	// for a pattern whose entire premise is inline styling — Visual_Check
-	// plus the interaction subtests below cover the right behavior.
-	// Follow-up: open an issue to mirror animate's cleanup in the highlight
-	// branch so downstream users get cleaner DOM.
+	// touches the subtree — including the first paint. Even with the
+	// post-cycle attribute cleanup landed in client v0.8.37
+	// (livetemplate/client#100), the in-flight state during the ~550ms cycle
+	// still has a non-empty `style` attribute that the [style] CSP rule would
+	// flag if UI_Standards happened to sample mid-cycle. The "no inline
+	// styles" rule isn't a meaningful guarantee for a pattern whose entire
+	// premise is inline styling — Visual_Check plus the interaction subtests
+	// below cover the right behavior.
 
 	t.Run("Increment_Flashes_Both_Highlight_Targets", func(t *testing.T) {
 		// directives.ts sets style.transition for ~550ms per render-touch.


### PR DESCRIPTION
## Summary

Comment-only change. The TestHighlightOnChange opt-out comment referenced a follow-up that has now shipped:

- **livetemplate/client#100** (the empty \`style\` attribute leak) → [client PR #105](https://github.com/livetemplate/client/pull/105) → released as **client v0.8.37**.

The comment is updated to record what landed and to explain why UI_Standards remains opt-out even after the fix:

- The directive's in-flight \`~550ms\` cycle still sets a non-empty \`style\` attribute on the highlight element (background-color + transition).
- UI_Standards' \`[style]\` CSP rule would flag it if the check happened to sample mid-cycle.
- The pattern's premise is inline styling, so the rule isn't a meaningful guarantee here regardless.

## Why not actually re-enable UI_Standards?

I tried. Even with a wait-for-cleanup gate before \`runUIStandardsWithPico\`, the surrounding \`Increment_Flashes_Both\` / \`Highlight_Cleans_Up_After_Duration\` subtests went from flaky-pass to flaky-fail under the timing shift the gate introduced. The test was already flagged as a known flake in earlier sessions (resource contention with many Chrome containers in test-all.sh). Dropping the re-enable here keeps this PR scoped to the genuinely durable change — the comment update.

## Test plan

- [x] Test still passes (run locally on v0.8.37 client)
- [x] Diff is comment-only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)