### PR TITLE
feat(patterns): sortable list with HTML5 drag-and-drop

### DIFF
--- a/patterns/data.go
+++ b/patterns/data.go
@@ -103,9 +103,6 @@ func pageSlice(dataset []Item, page, size int) []Item {
 	return slices.Clone(dataset[start:end])
 }
 
-// initialSortableItems returns the starting task list for the Sortable
-// List pattern. Six items is enough to make reordering visibly obvious
-// without crowding the page.
 func initialSortableItems() []SortableItem {
 	return []SortableItem{
 		{Key: "task-1", Name: "Design wireframes"},

--- a/patterns/data.go
+++ b/patterns/data.go
@@ -103,6 +103,20 @@ func pageSlice(dataset []Item, page, size int) []Item {
 	return slices.Clone(dataset[start:end])
 }
 
+// initialSortableItems returns the starting task list for the Sortable
+// List pattern. Six items is enough to make reordering visibly obvious
+// without crowding the page.
+func initialSortableItems() []SortableItem {
+	return []SortableItem{
+		{Key: "task-1", Name: "Design wireframes"},
+		{Key: "task-2", Name: "Write API spec"},
+		{Key: "task-3", Name: "Implement backend"},
+		{Key: "task-4", Name: "Build frontend"},
+		{Key: "task-5", Name: "Write tests"},
+		{Key: "task-6", Name: "Deploy to staging"},
+	}
+}
+
 // carMakes maps car makes to their model lists. Used by Value Select to
 // demonstrate cascading dependent selects.
 var carMakes = map[string][]string{
@@ -246,6 +260,7 @@ func allPatterns() []PatternCategory {
 				{Name: "Click To Load", Path: "/patterns/lists/click-to-load", Description: "Append-only pagination", Implemented: true},
 				{Name: "Infinite Scroll", Path: "/patterns/lists/infinite-scroll", Description: "Auto-load on scroll with IntersectionObserver", Implemented: true},
 				{Name: "Value Select", Path: "/patterns/lists/value-select", Description: "Cascading dependent selects", Implemented: true},
+				{Name: "Sortable List", Path: "/patterns/lists/sortable", Description: "Drag-and-drop reordering with native HTML5 drag events", Implemented: true},
 			},
 		},
 		{

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -172,3 +172,92 @@ func infiniteScrollHandler(baseOpts []livetemplate.Option) http.Handler {
 		HasMore:     true,
 	}))
 }
+
+// --- Pattern #12: Sortable List ---
+
+// SortableController shares an in-memory ordering across all sessions
+// (mirrors DeleteRowController's pattern) so reorders persist across
+// reloads and across browser tabs. This makes the "open two tabs and
+// drag in one" multi-user broadcast story work without any extra wiring.
+type SortableController struct {
+	mu    sync.Mutex
+	items []SortableItem
+}
+
+func newSortableController() *SortableController {
+	return &SortableController{items: initialSortableItems()}
+}
+
+func (c *SortableController) snapshot() []SortableItem {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.items)
+}
+
+func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
+	state.Items = c.snapshot()
+	return state, nil
+}
+
+// Reorder handles a drag-and-drop reorder. The client-side drag handler
+// puts the dragged item's data-key into ctx as "dragSourceKey" and the
+// drop target's data-key as "dragTargetKey".
+//
+// Algorithm: remove source by index, then insert before target's
+// (post-removal) index. Self-drop, missing keys, and unknown keys are
+// no-ops — important because cross-app drags or stale page state can
+// land here with values we don't recognize.
+func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
+	src := ctx.GetString("dragSourceKey")
+	tgt := ctx.GetString("dragTargetKey")
+	if src == "" || tgt == "" || src == tgt {
+		return state, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	srcIdx, tgtIdx := -1, -1
+	for i, it := range c.items {
+		if it.Key == src {
+			srcIdx = i
+		}
+		if it.Key == tgt {
+			tgtIdx = i
+		}
+	}
+	if srcIdx < 0 || tgtIdx < 0 {
+		return state, nil
+	}
+
+	moved := c.items[srcIdx]
+	c.items = slices.Delete(c.items, srcIdx, srcIdx+1)
+	if srcIdx < tgtIdx {
+		tgtIdx--
+	}
+	c.items = slices.Insert(c.items, tgtIdx, moved)
+
+	state.Items = slices.Clone(c.items)
+	return state, nil
+}
+
+// Reset restores the demo's initial ordering — wired to a button so
+// visitors can put the list back without restarting the server.
+func (c *SortableController) Reset(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
+	c.mu.Lock()
+	c.items = initialSortableItems()
+	c.mu.Unlock()
+	state.Items = c.snapshot()
+	return state, nil
+}
+
+func sortableHandler(baseOpts []livetemplate.Option) http.Handler {
+	opts := append(slices.Clone(baseOpts),
+		livetemplate.WithParseFiles("templates/layout.tmpl", "templates/lists/sortable.tmpl"),
+	)
+	tmpl := livetemplate.Must(livetemplate.New("layout", opts...))
+	return tmpl.Handle(newSortableController(), livetemplate.AsState(&SortableState{
+		Title:    "Sortable List",
+		Category: "Lists & Data",
+	}))
+}

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -173,10 +173,12 @@ func infiniteScrollHandler(baseOpts []livetemplate.Option) http.Handler {
 	}))
 }
 
-// --- Pattern #12: Sortable List ---
+// --- Sortable List ---
 
-// SortableController shares ordering across all sessions, so reorders
-// persist across reloads and broadcast to other tabs.
+// SortableController shares the list ordering across all sessions via
+// a process-wide mutex-protected slice, so reorders persist across
+// reloads and across tabs on next refresh. (Live multi-tab sync would
+// require Sync() / BroadcastAction — out of scope for this demo.)
 type SortableController struct {
 	mu    sync.Mutex
 	items []SortableItem

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -175,10 +175,7 @@ func infiniteScrollHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Sortable List ---
 
-// SortableController shares the list ordering across all sessions via
-// a process-wide mutex-protected slice, so reorders persist across
-// reloads and across tabs on next refresh. (Live multi-tab sync would
-// require Sync() / BroadcastAction — out of scope for this demo.)
+// SortableController holds the list ordering process-wide so it persists across reloads (live multi-tab sync would need Sync()).
 type SortableController struct {
 	mu    sync.Mutex
 	items []SortableItem
@@ -199,13 +196,7 @@ func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Contex
 	return state, nil
 }
 
-// Reorder reads the drag pair from ctx — dragSourceKey and dragTargetKey
-// are injected by the client (livetemplate/client) from the dragstart
-// element's data-key and the drop target's data-key, respectively.
-// Every return path repopulates state.Items from the locked snapshot —
-// the framework-provided value is per-session and may lag the shared
-// ordering, so trusting it on early-exit paths could overwrite the
-// rendered list with stale data.
+// Reorder reads dragSourceKey / dragTargetKey (injected by livetemplate/client from the source/target data-key) and always repopulates state.Items from the locked snapshot — the framework-provided value is per-session and may lag the shared ordering.
 func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
 	src := ctx.GetString("dragSourceKey")
 	tgt := ctx.GetString("dragTargetKey")

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -203,16 +203,20 @@ func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Contex
 // are injected by the client's drop handler from the dragged item's
 // data-key and the drop target's data-key, respectively. Missing/unknown/
 // equal keys are no-ops so cross-app drags and stale page state can't
-// corrupt the list.
+// corrupt the list. Every return path populates state.Items from the
+// authoritative snapshot — never the framework-provided value, which
+// could be stale relative to the live shared ordering.
 func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
 	src := ctx.GetString("dragSourceKey")
 	tgt := ctx.GetString("dragTargetKey")
-	if src == "" || tgt == "" || src == tgt {
-		return state, nil
-	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if src == "" || tgt == "" || src == tgt {
+		state.Items = slices.Clone(c.items)
+		return state, nil
+	}
 
 	srcIdx, tgtIdx := -1, -1
 	for i, it := range c.items {
@@ -227,6 +231,7 @@ func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Cont
 		}
 	}
 	if srcIdx < 0 || tgtIdx < 0 {
+		state.Items = slices.Clone(c.items)
 		return state, nil
 	}
 

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -199,13 +199,11 @@ func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Contex
 	return state, nil
 }
 
-// Reorder reads the drag pair from ctx — "dragSourceKey" and "dragTargetKey"
-// are injected by the client's drop handler from the dragged item's
-// data-key and the drop target's data-key, respectively. Missing/unknown/
-// equal keys are no-ops so cross-app drags and stale page state can't
-// corrupt the list. Every return path populates state.Items from the
-// authoritative snapshot — never the framework-provided value, which
-// could be stale relative to the live shared ordering.
+// Reorder reads the drag pair from ctx ("dragSourceKey", "dragTargetKey").
+// Every return path repopulates state.Items from the locked snapshot —
+// the framework-provided value is per-session and may lag the shared
+// ordering, so trusting it on early-exit paths could overwrite the
+// rendered list with stale data.
 func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
 	src := ctx.GetString("dragSourceKey")
 	tgt := ctx.GetString("dragTargetKey")

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -175,10 +175,8 @@ func infiniteScrollHandler(baseOpts []livetemplate.Option) http.Handler {
 
 // --- Pattern #12: Sortable List ---
 
-// SortableController shares an in-memory ordering across all sessions
-// (mirrors DeleteRowController's pattern) so reorders persist across
-// reloads and across browser tabs. This makes the "open two tabs and
-// drag in one" multi-user broadcast story work without any extra wiring.
+// SortableController shares ordering across all sessions, so reorders
+// persist across reloads and broadcast to other tabs.
 type SortableController struct {
 	mu    sync.Mutex
 	items []SortableItem
@@ -199,14 +197,11 @@ func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Contex
 	return state, nil
 }
 
-// Reorder handles a drag-and-drop reorder. The client-side drag handler
-// puts the dragged item's data-key into ctx as "dragSourceKey" and the
-// drop target's data-key as "dragTargetKey".
-//
-// Algorithm: remove source by index, then insert before target's
-// (post-removal) index. Self-drop, missing keys, and unknown keys are
-// no-ops — important because cross-app drags or stale page state can
-// land here with values we don't recognize.
+// Reorder reads the drag pair from ctx — "dragSourceKey" and "dragTargetKey"
+// are injected by the client's drop handler from the dragged item's
+// data-key and the drop target's data-key, respectively. Missing/unknown/
+// equal keys are no-ops so cross-app drags and stale page state can't
+// corrupt the list.
 func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
 	src := ctx.GetString("dragSourceKey")
 	tgt := ctx.GetString("dragTargetKey")
@@ -225,6 +220,9 @@ func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Cont
 		if it.Key == tgt {
 			tgtIdx = i
 		}
+		if srcIdx >= 0 && tgtIdx >= 0 {
+			break
+		}
 	}
 	if srcIdx < 0 || tgtIdx < 0 {
 		return state, nil
@@ -241,13 +239,11 @@ func (c *SortableController) Reorder(state SortableState, ctx *livetemplate.Cont
 	return state, nil
 }
 
-// Reset restores the demo's initial ordering — wired to a button so
-// visitors can put the list back without restarting the server.
 func (c *SortableController) Reset(state SortableState, ctx *livetemplate.Context) (SortableState, error) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.items = initialSortableItems()
-	c.mu.Unlock()
-	state.Items = c.snapshot()
+	state.Items = slices.Clone(c.items)
 	return state, nil
 }
 

--- a/patterns/handlers_lists.go
+++ b/patterns/handlers_lists.go
@@ -199,7 +199,9 @@ func (c *SortableController) Mount(state SortableState, ctx *livetemplate.Contex
 	return state, nil
 }
 
-// Reorder reads the drag pair from ctx ("dragSourceKey", "dragTargetKey").
+// Reorder reads the drag pair from ctx — dragSourceKey and dragTargetKey
+// are injected by the client (livetemplate/client) from the dragstart
+// element's data-key and the drop target's data-key, respectively.
 // Every return path repopulates state.Items from the locked snapshot —
 // the framework-provided value is per-session and may lag the shared
 // ordering, so trusting it on early-exit paths could overwrite the

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -74,7 +74,7 @@ func main() {
 	mux.Handle("/patterns/forms/file-upload", fileUploadHandler(baseOpts))
 	mux.Handle("/patterns/forms/preserve-inputs", preserveInputsHandler(baseOpts))
 
-	// Category: Lists & Data (#8–#11)
+	// Category: Lists & Data
 	mux.Handle("/patterns/lists/delete-row", deleteRowHandler(baseOpts))
 	mux.Handle("/patterns/lists/click-to-load", clickToLoadHandler(baseOpts))
 	mux.Handle("/patterns/lists/infinite-scroll", infiniteScrollHandler(baseOpts))

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -79,6 +79,7 @@ func main() {
 	mux.Handle("/patterns/lists/click-to-load", clickToLoadHandler(baseOpts))
 	mux.Handle("/patterns/lists/infinite-scroll", infiniteScrollHandler(baseOpts))
 	mux.Handle("/patterns/lists/value-select", valueSelectHandler(baseOpts))
+	mux.Handle("/patterns/lists/sortable", sortableHandler(baseOpts))
 
 	// Category: Search & Filtering (#12–#13)
 	mux.Handle("/patterns/search/active-search", activeSearchHandler(baseOpts))

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1281,8 +1281,10 @@ func TestSortable(t *testing.T) {
 
 		// time.Sleep (Go-side) is fine for negative assertions — the
 		// CLAUDE.md "no chromedp.Sleep" rule is about browser-side waits
-		// that hide timing bugs in positive assertions.
-		time.Sleep(500 * time.Millisecond)
+		// that hide timing bugs in positive assertions. 1s gives loaded
+		// CI runners headroom for any spurious server-side reorder to
+		// round-trip and surface in the assertion below.
+		time.Sleep(1 * time.Second)
 
 		var orderAfter string
 		if err := chromedp.Run(ctx, chromedp.Evaluate(

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1297,13 +1297,20 @@ func TestSortable(t *testing.T) {
 	})
 
 	t.Run("Reset_RestoresInitialOrder", func(t *testing.T) {
-		// After all the prior reorders, hit Reset and assert order is
-		// back to task-1..task-6.
+		// Scramble first so Reset has something to undo. Without this
+		// step the assertion would pass trivially when the list happened
+		// to already be in initial order.
 		var order string
 		err := chromedp.Run(ctx,
+			resetToInitial,
+			simulateDrag("task-3", "task-1"),
+			e2etest.WaitFor(
+				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-3'`,
+				5*time.Second,
+			),
 			chromedp.Click(`button[name="reset"]`, chromedp.ByQuery),
 			e2etest.WaitFor(
-				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-1'`,
+				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-1' && document.querySelectorAll('#sortable-list li')[5].dataset.key === 'task-6'`,
 				5*time.Second,
 			),
 			chromedp.Evaluate(

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1149,14 +1149,10 @@ func TestSortable(t *testing.T) {
 
 	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/sortable"
 
-	// Helper: simulate a full HTML5 drag-and-drop gesture by dispatching
-	// real DragEvent objects with a shared DataTransfer. This exercises the
-	// production client delegation pipeline (Layer A side-effects + Layer B
-	// data injection + WebSocket send) — it does NOT bypass the client
-	// like liveTemplateClient.send() would. CDP Input.dispatchMouseEvent
-	// is unreliable for HTML5 DnD in headless Docker Chrome (drag
-	// thresholds, screen-coordinate quirks), so synthetic DragEvent
-	// dispatch is the standard workaround.
+	// CDP Input.dispatchMouseEvent is unreliable for HTML5 DnD in headless
+	// Docker Chrome, so we dispatch real DragEvent objects with a shared
+	// DataTransfer instead. This still exercises the full client
+	// delegation pipeline — not a liveTemplateClient.send() shortcut.
 	simulateDrag := func(srcKey, tgtKey string) chromedp.Action {
 		js := fmt.Sprintf(`
 			(() => {
@@ -1247,10 +1243,8 @@ func TestSortable(t *testing.T) {
 	})
 
 	t.Run("SelfDrop_NoOp", func(t *testing.T) {
-		// Self-drop must NOT change the order. Capture the current first
-		// key, simulate dragging that item onto itself, then assert
-		// (via a polling condition with a short timeout — not a Sleep)
-		// that the order remains stable.
+		// No diff is emitted on self-drop, so we poll for 500ms and assert
+		// the order didn't change.
 		var firstBefore string
 		if err := chromedp.Run(ctx, chromedp.Evaluate(
 			`document.querySelectorAll('#sortable-list li')[0].dataset.key`,
@@ -1258,20 +1252,10 @@ func TestSortable(t *testing.T) {
 		)); err != nil {
 			t.Fatalf("Failed to read first key before self-drop: %v", err)
 		}
-
-		// Run the drag. The Reorder controller short-circuits on src==tgt,
-		// so no diff is emitted — there's no positive condition to wait
-		// for. Instead we wait for a short period and assert no change
-		// occurred. The wait is long enough for any spurious server-side
-		// reorder to round-trip (~500ms), but short enough not to mask
-		// real bugs.
 		if err := chromedp.Run(ctx, simulateDrag(firstBefore, firstBefore)); err != nil {
 			t.Fatalf("Self-drop dispatch failed: %v", err)
 		}
 
-		// Poll for max 500ms checking that the order doesn't change.
-		// If it changes within the window, e2etest.WaitFor will exit
-		// early and this is the bug.
 		var orderChanged bool
 		_ = chromedp.Run(ctx,
 			chromedp.Evaluate(

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1137,7 +1137,7 @@ func TestValueSelect(t *testing.T) {
 	})
 }
 
-// --- Pattern #12 (Lists): Sortable List ---
+// --- Sortable List ---
 
 func TestSortable(t *testing.T) {
 	if testing.Short() {
@@ -1191,13 +1191,26 @@ func TestSortable(t *testing.T) {
 
 	runStandardSubtests(t, ctx, false, "Sortable List — six task items each with a hamburger drag handle, in default order, plus a Reset Order button")
 
+	// resetToInitial restores the canonical task-1..task-6 order so each
+	// reorder subtest starts from a known state and doesn't depend on the
+	// previous one's outcome.
+	resetToInitial := chromedp.Tasks{
+		chromedp.Click(`button[name="reset"]`, chromedp.ByQuery),
+		e2etest.WaitFor(
+			`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-1' && document.querySelectorAll('#sortable-list li')[5].dataset.key === 'task-6'`,
+			5*time.Second,
+		),
+	}
+
 	t.Run("Reorder_DragForward", func(t *testing.T) {
-		// Drag task-1 onto task-3. Expected after-order:
-		//   task-2, task-3, task-1, task-4, task-5, task-6
-		// (task-1 removed from index 0, target task-3 at original index 2
-		// becomes index 1 after removal, task-1 inserted at index 1.)
+		// Initial: [task-1, task-2, task-3, task-4, task-5, task-6]
+		// Drag task-1 onto task-3 with insert-before-target semantics:
+		// task-1 is removed from index 0, the post-removal target index of
+		// task-3 is 1, and task-1 is inserted at index 1.
+		// Expected:  [task-2, task-1, task-3, task-4, task-5, task-6]
 		var order string
 		err := chromedp.Run(ctx,
+			resetToInitial,
 			simulateDrag("task-1", "task-3"),
 			e2etest.WaitFor(
 				`document.querySelectorAll('#sortable-list li')[1].dataset.key === 'task-1'`,
@@ -1218,14 +1231,17 @@ func TestSortable(t *testing.T) {
 	})
 
 	t.Run("Reorder_DragBackward", func(t *testing.T) {
-		// After forward: task-2, task-1, task-3, task-4, task-5, task-6
-		// Drag task-6 onto task-2. Expected after-order:
-		//   task-6, task-2, task-1, task-3, task-4, task-5
+		// Initial: [task-1, task-2, task-3, task-4, task-5, task-6]
+		// Drag task-6 onto task-2: task-6 is removed from index 5, no
+		// post-removal index adjustment (srcIdx > tgtIdx), task-6 inserted
+		// at task-2's index 1.
+		// Expected: [task-1, task-6, task-2, task-3, task-4, task-5]
 		var order string
 		err := chromedp.Run(ctx,
+			resetToInitial,
 			simulateDrag("task-6", "task-2"),
 			e2etest.WaitFor(
-				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-6'`,
+				`document.querySelectorAll('#sortable-list li')[1].dataset.key === 'task-6'`,
 				5*time.Second,
 			),
 			chromedp.Evaluate(
@@ -1236,43 +1252,47 @@ func TestSortable(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Backward drag failed: %v", err)
 		}
-		want := "task-6,task-2,task-1,task-3,task-4,task-5"
+		want := "task-1,task-6,task-2,task-3,task-4,task-5"
 		if order != want {
 			t.Errorf("Order after backward drag: got %q, want %q", order, want)
 		}
 	})
 
 	t.Run("SelfDrop_NoOp", func(t *testing.T) {
-		// No diff is emitted on self-drop, so we poll for 500ms and assert
-		// the order didn't change.
-		var firstBefore string
-		if err := chromedp.Run(ctx, chromedp.Evaluate(
-			`document.querySelectorAll('#sortable-list li')[0].dataset.key`,
-			&firstBefore,
-		)); err != nil {
-			t.Fatalf("Failed to read first key before self-drop: %v", err)
+		// The controller short-circuits when source == target, so no diff
+		// is emitted. We can't condition-wait on a state that should NOT
+		// change, so we wait long enough for any spurious server-side
+		// reorder to round-trip (~500ms) and assert order is unchanged.
+		var orderBefore string
+		if err := chromedp.Run(ctx,
+			resetToInitial,
+			chromedp.Evaluate(
+				`Array.from(document.querySelectorAll('#sortable-list li')).map(el => el.dataset.key).join(',')`,
+				&orderBefore,
+			),
+		); err != nil {
+			t.Fatalf("Failed to read order before self-drop: %v", err)
 		}
-		if err := chromedp.Run(ctx, simulateDrag(firstBefore, firstBefore)); err != nil {
+
+		firstKey := strings.Split(orderBefore, ",")[0]
+		if err := chromedp.Run(ctx, simulateDrag(firstKey, firstKey)); err != nil {
 			t.Fatalf("Self-drop dispatch failed: %v", err)
 		}
 
-		var orderChanged bool
-		_ = chromedp.Run(ctx,
-			chromedp.Evaluate(
-				`(async () => {
-					const start = Date.now();
-					while (Date.now() - start < 500) {
-						const first = document.querySelectorAll('#sortable-list li')[0].dataset.key;
-						if (first !== `+fmt.Sprintf("%q", firstBefore)+`) return true;
-						await new Promise(r => setTimeout(r, 50));
-					}
-					return false;
-				})()`,
-				&orderChanged,
-			),
-		)
-		if orderChanged {
-			t.Errorf("Self-drop changed order: first key was %s, then changed", firstBefore)
+		// time.Sleep (Go-side) is fine for negative assertions — the
+		// CLAUDE.md "no chromedp.Sleep" rule is about browser-side waits
+		// that hide timing bugs in positive assertions.
+		time.Sleep(500 * time.Millisecond)
+
+		var orderAfter string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(
+			`Array.from(document.querySelectorAll('#sortable-list li')).map(el => el.dataset.key).join(',')`,
+			&orderAfter,
+		)); err != nil {
+			t.Fatalf("Failed to read order after self-drop: %v", err)
+		}
+		if orderAfter != orderBefore {
+			t.Errorf("Self-drop changed order: was %q, now %q", orderBefore, orderAfter)
 		}
 	})
 

--- a/patterns/patterns_test.go
+++ b/patterns/patterns_test.go
@@ -1137,6 +1137,186 @@ func TestValueSelect(t *testing.T) {
 	})
 }
 
+// --- Pattern #12 (Lists): Sortable List ---
+
+func TestSortable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel, serverPort := setupTest(t)
+	defer cancel()
+
+	url := e2etest.GetChromeTestURL(serverPort) + "/patterns/lists/sortable"
+
+	// Helper: simulate a full HTML5 drag-and-drop gesture by dispatching
+	// real DragEvent objects with a shared DataTransfer. This exercises the
+	// production client delegation pipeline (Layer A side-effects + Layer B
+	// data injection + WebSocket send) — it does NOT bypass the client
+	// like liveTemplateClient.send() would. CDP Input.dispatchMouseEvent
+	// is unreliable for HTML5 DnD in headless Docker Chrome (drag
+	// thresholds, screen-coordinate quirks), so synthetic DragEvent
+	// dispatch is the standard workaround.
+	simulateDrag := func(srcKey, tgtKey string) chromedp.Action {
+		js := fmt.Sprintf(`
+			(() => {
+				const src = document.querySelector('#sortable-list li[data-key=%q]');
+				const tgt = document.querySelector('#sortable-list li[data-key=%q]');
+				if (!src || !tgt) throw new Error('source or target not found');
+				const dt = new DataTransfer();
+				src.dispatchEvent(new DragEvent('dragstart', {bubbles:true, cancelable:true, dataTransfer:dt}));
+				tgt.dispatchEvent(new DragEvent('dragover',  {bubbles:true, cancelable:true, dataTransfer:dt}));
+				tgt.dispatchEvent(new DragEvent('drop',      {bubbles:true, cancelable:true, dataTransfer:dt}));
+			})()
+		`, srcKey, tgtKey)
+		return chromedp.Evaluate(js, nil)
+	}
+
+	// Reset the demo's shared in-memory order at the start. The controller's
+	// state is process-wide so other tests (or a previous run of this test
+	// in dev) could leave the list reordered.
+	t.Run("Initial_Reset", func(t *testing.T) {
+		err := chromedp.Run(ctx,
+			chromedp.Navigate(url),
+			e2etest.WaitForWebSocketReady(5*time.Second),
+			chromedp.WaitVisible(`#sortable-list`, chromedp.ByQuery),
+			e2etest.ValidateNoTemplateExpressions("[data-lvt-id]"),
+			e2etest.WaitForCount(`#sortable-list li[data-key]`, 6, 5*time.Second),
+			chromedp.Click(`button[name="reset"]`, chromedp.ByQuery),
+			e2etest.WaitFor(
+				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-1'`,
+				5*time.Second,
+			),
+		)
+		if err != nil {
+			t.Fatalf("Failed to load + reset: %v", err)
+		}
+	})
+
+	runStandardSubtests(t, ctx, false, "Sortable List — six task items each with a hamburger drag handle, in default order, plus a Reset Order button")
+
+	t.Run("Reorder_DragForward", func(t *testing.T) {
+		// Drag task-1 onto task-3. Expected after-order:
+		//   task-2, task-3, task-1, task-4, task-5, task-6
+		// (task-1 removed from index 0, target task-3 at original index 2
+		// becomes index 1 after removal, task-1 inserted at index 1.)
+		var order string
+		err := chromedp.Run(ctx,
+			simulateDrag("task-1", "task-3"),
+			e2etest.WaitFor(
+				`document.querySelectorAll('#sortable-list li')[1].dataset.key === 'task-1'`,
+				5*time.Second,
+			),
+			chromedp.Evaluate(
+				`Array.from(document.querySelectorAll('#sortable-list li')).map(el => el.dataset.key).join(',')`,
+				&order,
+			),
+		)
+		if err != nil {
+			t.Fatalf("Forward drag failed: %v", err)
+		}
+		want := "task-2,task-1,task-3,task-4,task-5,task-6"
+		if order != want {
+			t.Errorf("Order after forward drag: got %q, want %q", order, want)
+		}
+	})
+
+	t.Run("Reorder_DragBackward", func(t *testing.T) {
+		// After forward: task-2, task-1, task-3, task-4, task-5, task-6
+		// Drag task-6 onto task-2. Expected after-order:
+		//   task-6, task-2, task-1, task-3, task-4, task-5
+		var order string
+		err := chromedp.Run(ctx,
+			simulateDrag("task-6", "task-2"),
+			e2etest.WaitFor(
+				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-6'`,
+				5*time.Second,
+			),
+			chromedp.Evaluate(
+				`Array.from(document.querySelectorAll('#sortable-list li')).map(el => el.dataset.key).join(',')`,
+				&order,
+			),
+		)
+		if err != nil {
+			t.Fatalf("Backward drag failed: %v", err)
+		}
+		want := "task-6,task-2,task-1,task-3,task-4,task-5"
+		if order != want {
+			t.Errorf("Order after backward drag: got %q, want %q", order, want)
+		}
+	})
+
+	t.Run("SelfDrop_NoOp", func(t *testing.T) {
+		// Self-drop must NOT change the order. Capture the current first
+		// key, simulate dragging that item onto itself, then assert
+		// (via a polling condition with a short timeout — not a Sleep)
+		// that the order remains stable.
+		var firstBefore string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(
+			`document.querySelectorAll('#sortable-list li')[0].dataset.key`,
+			&firstBefore,
+		)); err != nil {
+			t.Fatalf("Failed to read first key before self-drop: %v", err)
+		}
+
+		// Run the drag. The Reorder controller short-circuits on src==tgt,
+		// so no diff is emitted — there's no positive condition to wait
+		// for. Instead we wait for a short period and assert no change
+		// occurred. The wait is long enough for any spurious server-side
+		// reorder to round-trip (~500ms), but short enough not to mask
+		// real bugs.
+		if err := chromedp.Run(ctx, simulateDrag(firstBefore, firstBefore)); err != nil {
+			t.Fatalf("Self-drop dispatch failed: %v", err)
+		}
+
+		// Poll for max 500ms checking that the order doesn't change.
+		// If it changes within the window, e2etest.WaitFor will exit
+		// early and this is the bug.
+		var orderChanged bool
+		_ = chromedp.Run(ctx,
+			chromedp.Evaluate(
+				`(async () => {
+					const start = Date.now();
+					while (Date.now() - start < 500) {
+						const first = document.querySelectorAll('#sortable-list li')[0].dataset.key;
+						if (first !== `+fmt.Sprintf("%q", firstBefore)+`) return true;
+						await new Promise(r => setTimeout(r, 50));
+					}
+					return false;
+				})()`,
+				&orderChanged,
+			),
+		)
+		if orderChanged {
+			t.Errorf("Self-drop changed order: first key was %s, then changed", firstBefore)
+		}
+	})
+
+	t.Run("Reset_RestoresInitialOrder", func(t *testing.T) {
+		// After all the prior reorders, hit Reset and assert order is
+		// back to task-1..task-6.
+		var order string
+		err := chromedp.Run(ctx,
+			chromedp.Click(`button[name="reset"]`, chromedp.ByQuery),
+			e2etest.WaitFor(
+				`document.querySelectorAll('#sortable-list li')[0].dataset.key === 'task-1'`,
+				5*time.Second,
+			),
+			chromedp.Evaluate(
+				`Array.from(document.querySelectorAll('#sortable-list li')).map(el => el.dataset.key).join(',')`,
+				&order,
+			),
+		)
+		if err != nil {
+			t.Fatalf("Reset failed: %v", err)
+		}
+		want := "task-1,task-2,task-3,task-4,task-5,task-6"
+		if order != want {
+			t.Errorf("Order after reset: got %q, want %q", order, want)
+		}
+	})
+}
+
 // --- Pattern #12: Active Search ---
 
 func TestActiveSearch(t *testing.T) {

--- a/patterns/state_lists.go
+++ b/patterns/state_lists.go
@@ -35,16 +35,14 @@ type ValueSelectState struct {
 	Model    string
 }
 
-// SortableState holds the state for the Sortable List pattern (#12).
 type SortableState struct {
 	Title    string
 	Category string
 	Items    []SortableItem
 }
 
-// SortableItem is a keyed task in the Sortable List pattern. Key drives
-// data-key in the template, which is what the diff engine and the
-// drag-and-drop client use to identify which item moved.
+// Key is wired to data-key in the template — the stable identity the
+// diff engine and the drag-and-drop client use to track which item moved.
 type SortableItem struct {
 	Key  string
 	Name string

--- a/patterns/state_lists.go
+++ b/patterns/state_lists.go
@@ -34,3 +34,18 @@ type ValueSelectState struct {
 	Make     string
 	Model    string
 }
+
+// SortableState holds the state for the Sortable List pattern (#12).
+type SortableState struct {
+	Title    string
+	Category string
+	Items    []SortableItem
+}
+
+// SortableItem is a keyed task in the Sortable List pattern. Key drives
+// data-key in the template, which is what the diff engine and the
+// drag-and-drop client use to identify which item moved.
+type SortableItem struct {
+	Key  string
+	Name string
+}

--- a/patterns/state_lists.go
+++ b/patterns/state_lists.go
@@ -41,8 +41,6 @@ type SortableState struct {
 	Items    []SortableItem
 }
 
-// Key is wired to data-key in the template — the stable identity the
-// diff engine and the drag-and-drop client use to track which item moved.
 type SortableItem struct {
 	Key  string
 	Name string

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -4,7 +4,9 @@
         <h3>Sortable List</h3>
         <p><small>Drag any row to reorder (mouse only; no keyboard path or visual drop-zone highlighting in this demo). The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
     </hgroup>
-    <ul id="sortable-list" aria-label="Reorderable task list">
+    <ul id="sortable-list"
+        aria-label="Reorderable task list"
+        aria-description="Use a mouse to drag items. Keyboard reordering is not supported in this demo.">
     {{range .Items}}
         <li data-key="{{.Key}}"
             draggable="true"

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -2,7 +2,7 @@
 <article>
     <hgroup>
         <h3>Sortable List</h3>
-        <p><small>Drag any row to reorder (mouse only — no keyboard reorder path in this demo). The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
+        <p><small>Drag any row to reorder (mouse only; no keyboard path or visual drop-zone highlighting in this demo). The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
     </hgroup>
     <ul id="sortable-list" aria-label="Reorderable task list">
     {{range .Items}}

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -4,9 +4,10 @@
         <h3>Sortable List</h3>
         <p><small>Drag any row to reorder (mouse only; no keyboard path or visual drop-zone highlighting in this demo). The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
     </hgroup>
+    <p id="sortable-list-desc" class="visually-hidden">Use a mouse to drag items. Keyboard reordering is not supported in this demo.</p>
     <ul id="sortable-list"
         aria-label="Reorderable task list"
-        aria-description="Use a mouse to drag items. Keyboard reordering is not supported in this demo.">
+        aria-describedby="sortable-list-desc">
     {{range .Items}}
         <li data-key="{{.Key}}"
             draggable="true"

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -2,7 +2,7 @@
 <article>
     <hgroup>
         <h3>Sortable List</h3>
-        <p><small>Drag any row by its handle to reorder. The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
+        <p><small>Drag any row to reorder (mouse only — no keyboard reorder path in this demo). The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
     </hgroup>
     <ul id="sortable-list" aria-label="Reorderable task list">
     {{range .Items}}

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -2,9 +2,9 @@
 <article>
     <hgroup>
         <h3>Sortable List</h3>
-        <p><small>Drag any row to reorder. The diff engine sends only an <code>["o", newKeys]</code> reorder op — no full re-render. Reorders persist across reloads and tabs (in-memory shared state). Use Reset to restore the initial order.</small></p>
+        <p><small>Drag any row by its handle to reorder. The new order persists across reloads. Use Reset Order to restore the initial sequence.</small></p>
     </hgroup>
-    <ul id="sortable-list">
+    <ul id="sortable-list" aria-label="Reorderable task list">
     {{range .Items}}
         <li data-key="{{.Key}}"
             draggable="true"

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -8,8 +8,8 @@
     {{range .Items}}
         <li data-key="{{.Key}}"
             draggable="true"
-            lvt-on:dragstart="reorder"
-            lvt-on:dragover="reorder" lvt-mod:throttle="100"
+            lvt-on:dragstart=""
+            lvt-on:dragover=""
             lvt-on:drop="reorder">
             <span aria-hidden="true">&#9776;</span> {{.Name}}
         </li>

--- a/patterns/templates/lists/sortable.tmpl
+++ b/patterns/templates/lists/sortable.tmpl
@@ -1,0 +1,22 @@
+{{define "content"}}
+<article>
+    <hgroup>
+        <h3>Sortable List</h3>
+        <p><small>Drag any row to reorder. The diff engine sends only an <code>["o", newKeys]</code> reorder op — no full re-render. Reorders persist across reloads and tabs (in-memory shared state). Use Reset to restore the initial order.</small></p>
+    </hgroup>
+    <ul id="sortable-list">
+    {{range .Items}}
+        <li data-key="{{.Key}}"
+            draggable="true"
+            lvt-on:dragstart="reorder"
+            lvt-on:dragover="reorder" lvt-mod:throttle="100"
+            lvt-on:drop="reorder">
+            <span aria-hidden="true">&#9776;</span> {{.Name}}
+        </li>
+    {{end}}
+    </ul>
+    <form method="POST">
+        <button name="reset" class="secondary outline">Reset Order</button>
+    </form>
+</article>
+{{end}}


### PR DESCRIPTION
## Summary

Adds the Sortable List pattern (under "Lists & Data"), demonstrating the new `lvt-on:dragstart` / `lvt-on:dragover` / `lvt-on:drop` event support shipped in [livetemplate/client#106](https://github.com/livetemplate/client/pull/106).

- Pattern URL: `/patterns/lists/sortable`
- Template is a plain `<ul>` of `draggable="true"` `<li>`s with `data-key`, using the **marker pattern** for dragstart/dragover (empty action) so only the drop event sends to the server. Pure HTML — zero custom JavaScript.
- `SortableController` follows the same process-wide in-memory `sync.Mutex`-backed pattern as `DeleteRowController`, so reorders persist across reloads and are visible to other tabs on next refresh. (Live multi-tab sync would require `Sync()` / `BroadcastAction` — out of scope for this demo.) A Reset Order button restores the initial sequence.
- `Reorder()` reads `dragSourceKey` / `dragTargetKey` from ctx and applies a remove-then-insert with index adjustment. Self-drop, missing keys, and unknown keys are all guarded no-ops (so cross-app drags or stale page state can't corrupt the list).
- The diff engine emits a single `["o", newKeys]` op per drop — no full re-render.

## Dependency

This PR's CI **will fail** until [livetemplate/client#106](https://github.com/livetemplate/client/pull/106) is merged and released to npm. The example template references `@livetemplate/client@latest` from CDN in production / `e2etest.ServeClientLibrary` in test mode, neither of which has the new drag events yet. Sequence of events:

1. Land livetemplate/client#106
2. Run `release.sh` to cut v0.8.38 to npm
3. CI on this PR turns green automatically

## Test plan

- [x] `TestSortable` — 5 subtests (Initial_Reset, Reorder_DragForward, Reorder_DragBackward, SelfDrop_NoOp, Reset_RestoresInitialOrder), all green when run with `LVT_LOCAL_CLIENT` pointing at the drag-events worktree's dist
- [x] Each Reorder subtest now resets to the initial order at the start, so subtests are independent (no chained-state failures)
- [x] `./test-all.sh` — full sweep across all 12 working examples passes with the local dist
- [x] Manually verified on iPhone over Tailscale — drag handles work, reorders persist across reloads

## E2E strategy note

The drag is simulated by dispatching real `DragEvent` objects with a shared `DataTransfer` via `chromedp.Evaluate`. CDP's `Input.dispatchMouseEvent` is unreliable for HTML5 DnD in headless Docker Chrome (drag-threshold and screen-coordinate quirks). The synthetic events still traverse the full client delegation pipeline — this is **not** a `liveTemplateClient.send()` shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)