### PR TITLE
docs(readme): align CDN string to @latest + add livetemplate.css link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The test script is also used in GitHub Actions. See `.github/workflows/test.yml`
 Examples are configured to use the CDN version of the client library:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.1.0/dist/livetemplate-client.browser.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
+<script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
 ```
 
 ### Development (Local)


### PR DESCRIPTION
## Summary

- The README's "Production (CDN)" example pinned `@livetemplate/client@0.1.0` while every example template under this repo uses `@latest`. This aligns the README to match what's actually shipped.
- Adds the `livetemplate.css` `<link>` that the canonical boilerplate (CLAUDE.md) loads alongside the client JS.

This pairs with [livetemplate#268](https://github.com/livetemplate/livetemplate/issues/268) — the rewritten livetemplate README uses the same `@latest` CSS+JS pair in its quick-start, so the two READMEs now show the same thing.

## Test plan

- [x] CDN URLs return 200 (`livetemplate.css` and `dist/livetemplate-client.browser.js` at `@latest`)
- [x] No template/code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)