### PR TITLE
deploy(patterns): Dockerfile + fly.toml for lt-patterns.fly.dev

### DIFF
--- a/patterns/.dockerignore
+++ b/patterns/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.worktrees
+.vscode
+.idea
+*.swp
+.DS_Store

--- a/patterns/Dockerfile
+++ b/patterns/Dockerfile
@@ -1,0 +1,37 @@
+# Phase 1 deployable image for the LiveTemplate patterns showcase.
+# Targets fly.io as `lt-patterns` so the docs site's external-app router
+# can proxy /patterns/ to it. Generic enough to run anywhere.
+#
+# Source is fetched at build time so the build context can be just the
+# patterns/ directory (makes flyctl deploys self-contained per app).
+
+ARG EXAMPLES_REF=docs/phase-1-patterns-deploy
+
+# ---- Build stage ----
+FROM golang:1.26-alpine AS go-builder
+ARG EXAMPLES_REF
+RUN apk add --no-cache git ca-certificates
+ENV GOTOOLCHAIN=auto
+WORKDIR /src
+RUN git clone --depth=1 --branch=${EXAMPLES_REF} https://github.com/livetemplate/examples.git .
+WORKDIR /src/patterns
+RUN go mod download -C ..
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /out/patterns .
+
+# ---- Runtime stage ----
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata
+RUN adduser -D -u 1000 patterns
+WORKDIR /app
+COPY --from=go-builder /out/patterns /usr/local/bin/patterns
+# Templates are loaded by livetemplate.WithParseFiles at runtime as
+# relative paths (e.g. "templates/layout.tmpl"), so cwd must contain
+# the templates/ directory at process start.
+COPY --from=go-builder /src/patterns/templates /app/templates
+RUN chown -R patterns:patterns /app
+USER patterns
+EXPOSE 8080
+ENV PORT=8080
+CMD ["patterns"]

--- a/patterns/fly.toml
+++ b/patterns/fly.toml
@@ -1,0 +1,20 @@
+# Deployment of the LiveTemplate patterns showcase.
+# Used by the docs site's external-app router to source live demos.
+
+app = "lt-patterns"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512


### PR DESCRIPTION
The patterns app already has a runnable main.go with PORT env var support and graceful shutdown. This adds the deployment artifacts so fly.io can build and run it as a standalone app at https://lt-patterns.fly.dev/.

## What's in this PR

- `patterns/Dockerfile` — multi-stage build that clones the examples repo at build time, builds the patterns Go binary, ships a 14 MB Alpine runtime with binary + templates/.
- `patterns/fly.toml` — fly.io app config (sjc region, shared 1cpu/512mb, auto-stop on idle).
- `patterns/.dockerignore` — standard ignores.

## Why clone-from-source?

The fly.io build context is the patterns/ directory (where fly.toml lives). The patterns app needs the parent module (sibling packages, go.mod). Rather than restructure to put fly.toml at the repo root, the Dockerfile clones the examples repo at build time. Once this PR merges, the EXAMPLES_REF default switches from this branch name to "main".

## Verification

App is already deployed and serving at https://lt-patterns.fly.dev/. The 31 pattern routes return 200; e.g. /patterns/forms/click-to-edit returns the interactive UI.

This unlocks the docs site's external-app router (livetemplate/tinkerdown PR #231) — the docs site at livetemplate-docs-staging.fly.dev proxies /patterns/<category>/* to this deployment.