### PR TITLE
feat(patterns): /api/index.json catalog endpoint

### DIFF
--- a/patterns/api_index.go
+++ b/patterns/api_index.go
@@ -39,6 +39,18 @@ type apiPattern struct {
 // in a way that breaks existing consumers.
 func apiIndexHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// CORS preflight first: a browser fetch from the docs site will
+		// OPTIONS-preflight on any cross-origin request that the spec
+		// considers non-simple. Reply with the same Allow-Origin we'd
+		// send for the actual GET so the real request goes through.
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return

--- a/patterns/api_index.go
+++ b/patterns/api_index.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// apiCategory and apiPattern are the JSON shapes the docs site catalog
+// consumes from /api/index.json. Kept separate from PatternLink so the
+// internal model can evolve without breaking the public schema.
+type apiCategory struct {
+	Slug     string       `json:"slug"`
+	Name     string       `json:"name"`
+	Patterns []apiPattern `json:"patterns"`
+}
+
+type apiPattern struct {
+	Slug        string `json:"slug"`        // last URL segment, e.g. "click-to-edit"
+	Name        string `json:"name"`        // human title
+	Path        string `json:"path"`        // upstream path, e.g. "/patterns/forms/click-to-edit"
+	Description string `json:"description"` // one-line problem statement
+	Status      string `json:"status"`      // "stable" | "soon"
+	Category    string `json:"category"`    // human category name (denormalized for client convenience)
+}
+
+// apiIndexHandler exposes the pattern catalog as JSON for the
+// LiveTemplate docs site (and any other consumer that wants to embed
+// the catalog without scraping HTML).
+//
+// Response shape:
+//
+//	{
+//	  "version": 1,
+//	  "categories": [{slug, name, patterns: [{slug, name, path, description, status, category}]}]
+//	}
+//
+// Versioned for forward-compat: bump `version` when the schema changes
+// in a way that breaks existing consumers.
+func apiIndexHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		categories := allPatterns()
+		out := struct {
+			Version    int           `json:"version"`
+			Categories []apiCategory `json:"categories"`
+		}{
+			Version:    1,
+			Categories: make([]apiCategory, 0, len(categories)),
+		}
+		for _, c := range categories {
+			ac := apiCategory{
+				Slug:     categorySlug(c.Name),
+				Name:     c.Name,
+				Patterns: make([]apiPattern, 0, len(c.Patterns)),
+			}
+			for _, p := range c.Patterns {
+				status := "stable"
+				if !p.Implemented {
+					status = "soon"
+				}
+				ac.Patterns = append(ac.Patterns, apiPattern{
+					Slug:        patternSlugFromPath(p.Path),
+					Name:        p.Name,
+					Path:        p.Path,
+					Description: p.Description,
+					Status:      status,
+					Category:    c.Name,
+				})
+			}
+			out.Categories = append(out.Categories, ac)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// Cached aggressively at fly's edge; this index is authoritatively
+		// produced from compiled-in code so it only changes on redeploy.
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		// Allow the docs site (and any operator script) to fetch this
+		// from a different origin without a separate CORS proxy.
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		_ = json.NewEncoder(w).Encode(out)
+	})
+}
+
+// categorySlug derives a URL-safe slug from a category name. e.g.
+// "Forms & Editing" -> "forms-editing". Used as a stable id the docs
+// catalog can address without depending on the human display name.
+func categorySlug(name string) string {
+	out := strings.ToLower(name)
+	out = strings.ReplaceAll(out, "&", "")
+	// collapse runs of non-alnum to a single dash
+	var b strings.Builder
+	prevDash := true
+	for _, r := range out {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		case !prevDash:
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// patternSlugFromPath extracts the pattern's last URL segment.
+// "/patterns/forms/click-to-edit" -> "click-to-edit".
+func patternSlugFromPath(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}

--- a/patterns/api_index_test.go
+++ b/patterns/api_index_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCategorySlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Forms & Editing", "forms-editing"},
+		{"Lists & Data", "lists-data"},
+		{"Search & Filtering", "search-filtering"},
+		{"Loading & Progress", "loading-progress"},
+		{"Dialogs, Tabs & Navigation", "dialogs-tabs-navigation"},
+		{"Feedback & Animations", "feedback-animations"},
+		{"Real-Time", "real-time"},
+		{"  Trim me  ", "trim-me"},
+	}
+	for _, c := range cases {
+		if got := categorySlug(c.in); got != c.want {
+			t.Errorf("categorySlug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPatternSlugFromPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/patterns/forms/click-to-edit", "click-to-edit"},
+		{"/patterns/lists/delete-row", "delete-row"},
+		{"no-slash", "no-slash"},
+	}
+	for _, c := range cases {
+		if got := patternSlugFromPath(c.in); got != c.want {
+			t.Errorf("patternSlugFromPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAPIIndex_StructureAndContents(t *testing.T) {
+	srv := httptest.NewServer(apiIndexHandler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if cors := resp.Header.Get("Access-Control-Allow-Origin"); cors != "*" {
+		t.Errorf("missing CORS header for cross-origin docs-site fetch: %q", cors)
+	}
+
+	var body struct {
+		Version    int           `json:"version"`
+		Categories []apiCategory `json:"categories"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Version != 1 {
+		t.Errorf("version = %d, want 1 (bump only when schema breaks)", body.Version)
+	}
+
+	if len(body.Categories) == 0 {
+		t.Fatal("no categories returned")
+	}
+
+	// Spot-check the canonical first pattern is present and well-formed.
+	var firstPattern *apiPattern
+	for _, c := range body.Categories {
+		if len(c.Patterns) > 0 {
+			firstPattern = &c.Patterns[0]
+			break
+		}
+	}
+	if firstPattern == nil {
+		t.Fatal("no patterns in any category")
+	}
+	if firstPattern.Slug == "" || firstPattern.Name == "" || firstPattern.Path == "" {
+		t.Errorf("first pattern has empty fields: %+v", firstPattern)
+	}
+	if !strings.HasPrefix(firstPattern.Path, "/patterns/") {
+		t.Errorf("first pattern path doesn't look like a pattern URL: %q", firstPattern.Path)
+	}
+	if firstPattern.Status != "stable" && firstPattern.Status != "soon" {
+		t.Errorf("first pattern status %q must be stable|soon", firstPattern.Status)
+	}
+	if firstPattern.Category == "" {
+		t.Error("category denormalized field should be set")
+	}
+}
+
+func TestAPIIndex_HEADRequest(t *testing.T) {
+	srv := httptest.NewServer(apiIndexHandler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodHead, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("HEAD status = %d", resp.StatusCode)
+	}
+}
+
+func TestAPIIndex_RejectsNonGET(t *testing.T) {
+	srv := httptest.NewServer(apiIndexHandler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("POST status = %d, want 405", resp.StatusCode)
+	}
+}
+
+// Catch the common drift case: a handler is registered in main.go but
+// never made it into allPatterns() (or vice versa). The API consumer
+// expects the catalog to mirror what's actually served.
+func TestAPIIndex_AllPatternsHaveImplementedHandlers(t *testing.T) {
+	categories := allPatterns()
+	if len(categories) == 0 {
+		t.Fatal("allPatterns() returned no categories")
+	}
+	count := 0
+	for _, c := range categories {
+		count += len(c.Patterns)
+	}
+	if count < 30 {
+		t.Errorf("got %d patterns; expected at least 30 (drift between data.go and main.go?)", count)
+	}
+}

--- a/patterns/api_index_test.go
+++ b/patterns/api_index_test.go
@@ -130,6 +130,35 @@ func TestAPIIndex_RejectsNonGET(t *testing.T) {
 	}
 }
 
+// CORS preflight from cross-origin browsers (the docs site fetching
+// from lt-patterns.fly.dev) MUST succeed or the actual GET never
+// fires. Reviewer flagged this on the initial PR.
+func TestAPIIndex_OPTIONSPreflightSucceeds(t *testing.T) {
+	srv := httptest.NewServer(apiIndexHandler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL, nil)
+	req.Header.Set("Origin", "https://livetemplate.fly.dev")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("OPTIONS status = %d, want 204", resp.StatusCode)
+	}
+	if origin := resp.Header.Get("Access-Control-Allow-Origin"); origin != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want *", origin)
+	}
+	allow := resp.Header.Get("Access-Control-Allow-Methods")
+	if !strings.Contains(allow, "GET") {
+		t.Errorf("Access-Control-Allow-Methods %q must include GET", allow)
+	}
+}
+
 // Catch the common drift case: a handler is registered in main.go but
 // never made it into allPatterns() (or vice versa). The API consumer
 // expects the catalog to mirror what's actually served.

--- a/patterns/main.go
+++ b/patterns/main.go
@@ -112,6 +112,10 @@ func main() {
 	mux.Handle("/patterns/realtime/live-preview", livePreviewHandler(baseOpts))
 	mux.Handle("/patterns/realtime/server-push", serverPushHandler(baseOpts))
 
+	// JSON catalog index — consumed by the LiveTemplate docs site to
+	// render its patterns landing page without scraping HTML.
+	mux.Handle("/api/index.json", apiIndexHandler())
+
 	// Client library and CSS (dev mode)
 	if localClient := os.Getenv("LVT_LOCAL_CLIENT"); localClient != "" {
 		mux.HandleFunc("/livetemplate-client.js", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Phase 4 Track A. Adds a JSON endpoint exposing the pattern catalog so the LiveTemplate docs site can render its catalog page without HTML-scraping.

Schema is versioned and CORS-enabled. Smoke-verified locally: 7 categories, 33 patterns. 6 new unit tests; existing patterns_test.go (chromedp e2e) untouched.

Wired in main.go at `/api/index.json`. Once merged + lt-patterns redeployed, the docs site at https://livetemplate-docs-staging.fly.dev/patterns/ can fetch from https://lt-patterns.fly.dev/api/index.json.