### PR TITLE
docs(README): cross-link to https://livetemplate.fly.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Example applications demonstrating LiveTemplate usage with various features and patterns.
 
+📚 **Framework documentation:** **<https://livetemplate.fly.dev>** — guides, recipes, patterns catalog (with live demos), full reference. The `/examples` and `/patterns` sections of the docs site index every app in this repo.
+
 ## Showcase: Todo App
 
 The todo app demonstrates LiveTemplate's core features in ~150 lines of Go + ~80 lines of HTML:


### PR DESCRIPTION
Add prominent link to the public framework docs site at the top of the README. The `/examples` and `/patterns` sections there index every app in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)