### PR TITLE
chore(patterns): pin @livetemplate/client to v0.8.41

### DIFF
--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="/livetemplate.css">
     <script defer src="/livetemplate-client.js"></script>
     {{else}}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.41/livetemplate.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.41/dist/livetemplate-client.browser.js"></script>
     {{end}}
 </head>
 <body>


### PR DESCRIPTION
## Summary

Pins `@livetemplate/client` from `@latest` to `@0.8.41` in `patterns/templates/layout.tmpl`.

## Why

v0.8.41 ships livetemplate/client#119 — full reload when SPA navigation crosses an app boundary. The patterns app loads via the docs site's reverse proxy at `/patterns/*`, and its client library was the one intercepting cross-app link clicks (e.g. clicking the "Patterns" header link with `href=\"/\"` from a pattern detail page) and silently patching the docs body into a page whose head still pointed at the patterns app's stylesheets.

Pinning (vs. `@latest`) gates the fix on this branch's deploy rather than waiting for jsdelivr's edge cache on `@latest` to rotate (typically up to 12 hours). Once the dust settles we'll revert to `@latest` so client patches keep flowing automatically.

## Test plan

- [x] Pin verified in `patterns/templates/layout.tmpl`
- [ ] Post-merge: deploy lt-patterns via flyctl, verify rendered HTML references `@0.8.41`, ask user to retry the original repro on iOS