### PR TITLE
chore(patterns): pin @livetemplate/client to v0.8.42

### DIFF
--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="/livetemplate.css">
     <script defer src="/livetemplate-client.js"></script>
     {{else}}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.41/livetemplate.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.41/dist/livetemplate-client.browser.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.42/livetemplate.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.42/dist/livetemplate-client.browser.js"></script>
     {{end}}
 </head>
 <body>


### PR DESCRIPTION
## Summary

Bump `@livetemplate/client` from `@0.8.41` → `@0.8.42` in `patterns/templates/layout.tmpl`. v0.8.42 ships the no-wrapper-path fix (livetemplate/client@369a060) — the cross-app stylesheet check now runs before either body-swap branch in `handleNavigationResponse`, so it correctly fires when the destination has no `[data-lvt-id]` (the patterns app → docs root case that 0.8.41 missed).

## Test plan

- [x] Pin verified
- [ ] Post-merge: redeploy lt-patterns (`flyctl deploy --no-cache --build-arg EXAMPLES_REF=main`); verify rendered HTML references `@0.8.42`; rerun the chromedp repro to confirm the bug is gone.