### PR TITLE
chore(patterns): revert @livetemplate/client back to @latest

### DIFF
--- a/patterns/templates/layout.tmpl
+++ b/patterns/templates/layout.tmpl
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="/livetemplate.css">
     <script defer src="/livetemplate-client.js"></script>
     {{else}}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.42/livetemplate.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@0.8.42/dist/livetemplate-client.browser.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/livetemplate.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/@livetemplate/client@latest/dist/livetemplate-client.browser.js"></script>
     {{end}}
 </head>
 <body>


### PR DESCRIPTION
Both 0.8.41 and 0.8.42 ship the cross-app SPA-nav fix (livetemplate/client#119) and are well-baked in production. Returning to `@latest` so the patterns app continues to pick up future client patches automatically — the explicit pins were a temporary workaround to bypass jsdelivr's @latest edge cache while we verified the fix end-to-end.