### PR TITLE
test(live-preview): assert capabilities contains 'change', not exact equality

### DIFF
--- a/live-preview/live_preview_test.go
+++ b/live-preview/live_preview_test.go
@@ -98,8 +98,11 @@ func dialWebSocket(t *testing.T, port int) *websocket.Conn {
 	return conn
 }
 
-// TestWebSocketCapabilities verifies the initial WebSocket render includes
-// "change" in the capabilities metadata.
+// TestWebSocketCapabilities verifies the initial WebSocket render advertises
+// "change" in the capabilities metadata. Other capabilities (e.g.,
+// "progressive_enhancement", "validate", "upload") may also be present
+// depending on controller methods and config (see livetemplate#252); the
+// test asserts presence of "change" without requiring exact equality.
 func TestWebSocketCapabilities(t *testing.T) {
 	port, _ := startServer(t)
 	conn := dialWebSocket(t, port)
@@ -128,8 +131,15 @@ func TestWebSocketCapabilities(t *testing.T) {
 		t.Skip("capabilities not present in meta — requires livetemplate#253")
 	}
 
-	if len(caps) != 1 || caps[0] != "change" {
-		t.Errorf("Expected capabilities=[\"change\"], got %v", caps)
+	hasChange := false
+	for _, c := range caps {
+		if c == "change" {
+			hasChange = true
+			break
+		}
+	}
+	if !hasChange {
+		t.Errorf("Expected capabilities to include \"change\", got %v", caps)
 	}
 }
 


### PR DESCRIPTION
## Summary

[livetemplate PR #395](https://github.com/livetemplate/livetemplate/pull/395) (issue #252) extends the auto-detected capabilities list with `"progressive_enhancement"`, `"validate"`, and `"upload"`. The existing `TestWebSocketCapabilities` equality assertion (`len(caps) != 1 || caps[0] != "change"`) broke when run against that PR's core changes via the cross-repo CI.

Switch to a `contains`-style check: the test's intent is "this app's controller advertises `change`", not "this is the only capability the framework supports". The latter is brittle and breaks whenever the framework's auto-detected capability set grows.

## Test plan

- [x] `go test ./live-preview/...` passes locally
- [x] Test still asserts presence of `"change"` (the original intent)
- [x] Test no longer fails when capabilities grow

🤖 Generated with [Claude Code](https://claude.com/claude-code)