### PR TITLE
Phase 6: README + planning-doc rewrites (Subscribe/Publish nomenclature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example applications demonstrating LiveTemplate usage with various features and 
 
 The todo app demonstrates LiveTemplate's core features in ~150 lines of Go + ~80 lines of HTML:
 
-- **Real-time sync** — open two tabs as the same user; changes appear instantly via an opt-in `ctx.Subscribe(ctx.SelfTopic())` in Mount plus an explicit `ctx.Publish(ctx.SelfTopic(), ...)` from each mutating action
+- **Real-time sync** — open two tabs as the same user; changes appear instantly via opt-in `ctx.Subscribe` / `ctx.Publish` (the two-step peer-fan-out pattern)
 - **Standard HTML forms** — `<form method="POST" name="add">` routes to `Add()` with zero configuration
 - **Live search & sort** — `Change()` auto-wires input events with 300ms debounce
 - **Validation** — `ErrorTag`, `AriaInvalid`, `AriaDisabled` template helpers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example applications demonstrating LiveTemplate usage with various features and 
 
 The todo app demonstrates LiveTemplate's core features in ~150 lines of Go + ~80 lines of HTML:
 
-- **Real-time sync** — open two tabs as the same user; changes appear instantly via opt-in `ctx.Subscribe` / `ctx.Publish` (the two-step peer-fan-out pattern)
+- **Real-time sync** — open two tabs as the same user; changes appear instantly via opt-in `ctx.Subscribe` / `ctx.Publish`
 - **Standard HTML forms** — `<form method="POST" name="add">` routes to `Add()` with zero configuration
 - **Live search & sort** — `Change()` auto-wires input events with 300ms debounce
 - **Validation** — `ErrorTag`, `AriaInvalid`, `AriaDisabled` template helpers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example applications demonstrating LiveTemplate usage with various features and 
 
 The todo app demonstrates LiveTemplate's core features in ~150 lines of Go + ~80 lines of HTML:
 
-- **Real-time sync** — open two tabs as the same user; changes appear instantly via explicit `BroadcastAction`
+- **Real-time sync** — open two tabs as the same user; changes appear instantly via an opt-in `ctx.Subscribe(ctx.SelfTopic())` in Mount plus an explicit `ctx.Publish(ctx.SelfTopic(), ...)` from each mutating action
 - **Standard HTML forms** — `<form method="POST" name="add">` routes to `Add()` with zero configuration
 - **Live search & sort** — `Change()` auto-wires input events with 300ms debounce
 - **Validation** — `ErrorTag`, `AriaInvalid`, `AriaDisabled` template helpers

--- a/docs/plans/improve-ui-ux.md
+++ b/docs/plans/improve-ui-ux.md
@@ -490,7 +490,7 @@ Record with screen capture (Kap, ffmpeg, or similar):
 1. Split screen: two browser windows side by side, both at `localhost:8080`
 2. Both logged in as `alice`
 3. Demo sequence:
-   - Tab A: Add "Buy groceries" → appears in Tab B via the Publish(SelfTopic(), "RefreshTodos", nil) fan-out, fade animation
+   - Tab A: Add "Buy groceries" → appears in Tab B via the `ctx.Publish(ctx.SelfTopic(), "RefreshTodos", nil)` fan-out, fade animation
    - Tab B: Toggle complete → strikethrough appears in Tab A, highlight flash
    - Tab A: Search "buy" → filters in Tab A only (independent per-tab)
    - Tab B: Delete with modal confirmation → disappears from Tab A

--- a/docs/plans/improve-ui-ux.md
+++ b/docs/plans/improve-ui-ux.md
@@ -470,7 +470,7 @@ Add a showcase section at the top of `README.md`, before the Progressive Complex
 
 The todo app demonstrates LiveTemplate's core features in ~150 lines of Go + ~80 lines of HTML:
 
-- **Real-time sync** — open two tabs as the same user; changes appear instantly via explicit `BroadcastAction`
+- **Real-time sync** — open two tabs as the same user; changes appear instantly via an opt-in `ctx.Subscribe(ctx.SelfTopic())` in Mount plus an explicit `ctx.Publish(ctx.SelfTopic(), ...)` from each mutating action
 - **Standard HTML forms** — `<form method="POST" name="add">` routes to `Add()` with zero configuration
 - **Live search & sort** — `Change()` auto-wires input events with 300ms debounce
 - **Validation** — `ErrorTag`, `AriaInvalid`, `AriaDisabled` template helpers
@@ -490,7 +490,7 @@ Record with screen capture (Kap, ffmpeg, or similar):
 1. Split screen: two browser windows side by side, both at `localhost:8080`
 2. Both logged in as `alice`
 3. Demo sequence:
-   - Tab A: Add "Buy groceries" → appears in Tab B via BroadcastAction, fade animation
+   - Tab A: Add "Buy groceries" → appears in Tab B via the Publish(SelfTopic(), "RefreshTodos", nil) fan-out, fade animation
    - Tab B: Toggle complete → strikethrough appears in Tab A, highlight flash
    - Tab A: Search "buy" → filters in Tab A only (independent per-tab)
    - Tab B: Delete with modal confirmation → disappears from Tab A

--- a/shared-notepad/notepad.tmpl
+++ b/shared-notepad/notepad.tmpl
@@ -41,7 +41,7 @@
             <header><strong>How it works</strong></header>
             <ul>
                 <li><strong>BasicAuth</strong> — each user gets an isolated session (alice's notes are separate from bob's)</li>
-                <li><strong>Real-time sync</strong> — Save in one tab refreshes the others for the same user</li>
+                <li><strong>ctx.Subscribe / ctx.Publish</strong> — Save in one tab refreshes the others for the same user</li>
                 <li>Notes persist across page refreshes within the same server session</li>
             </ul>
             <small>Demo credentials: any username, password <strong>demo</strong></small>

--- a/shared-notepad/notepad.tmpl
+++ b/shared-notepad/notepad.tmpl
@@ -41,7 +41,7 @@
             <header><strong>How it works</strong></header>
             <ul>
                 <li><strong>BasicAuth</strong> — each user gets an isolated session (alice's notes are separate from bob's)</li>
-                <li><strong>BroadcastAction</strong> — Save in one tab refreshes the others for the same user</li>
+                <li><strong>Subscribe + Publish</strong> — Mount-side opt-in plus an explicit Publish from Save refreshes the other tabs for the same user</li>
                 <li>Notes persist across page refreshes within the same server session</li>
             </ul>
             <small>Demo credentials: any username, password <strong>demo</strong></small>

--- a/shared-notepad/notepad.tmpl
+++ b/shared-notepad/notepad.tmpl
@@ -41,7 +41,7 @@
             <header><strong>How it works</strong></header>
             <ul>
                 <li><strong>BasicAuth</strong> — each user gets an isolated session (alice's notes are separate from bob's)</li>
-                <li><strong>Subscribe + Publish</strong> — Mount-side opt-in plus an explicit Publish from Save refreshes the other tabs for the same user</li>
+                <li><strong>Real-time sync</strong> — Save in one tab refreshes the others for the same user</li>
                 <li>Notes persist across page refreshes within the same server session</li>
             </ul>
             <small>Demo credentials: any username, password <strong>demo</strong></small>


### PR DESCRIPTION
Phase 6 of the broadcast-redesign wave (livetemplate#415) — examples side, **teaching-text-only** after rebase.

## Scope (post-rebase, net-new on top of origin/main)

examples#102 (already merged) covered the chat/shared-notepad/todos/landing-demo Go migrations + go.mod bump. This PR is the teaching-text companion that #102 didn't touch:

- `README.md` — "Real-time sync" bullet reframed to the two-step opt-in shape.
- `docs/plans/improve-ui-ux.md` — 2 sites in the showcase planning notes.
- `shared-notepad/notepad.tmpl` — "How it works" list bullet.

3 files, +4/-4.

## Audit-was-wrong note

Same recovery as livetemplate/docs#27 — original Phase 6 worktree branched off pre-#102 SHA and didn't notice the merged work. Rebase dropped the duplicates, kept only net-new teaching text.

## Companion PRs

- livetemplate#430, lvt#332, livetemplate/docs#27, livetemplate/tinkerdown#279, livetemplate/devbox-dash#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)