### PR TITLE
docs(examples): scrub residual broadcast vocabulary; bump livetemplate to v0.10.1

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -203,7 +203,7 @@ func main() {
 
     log.Printf("🚀 Chat server starting on http://localhost:%s", port)
     log.Println("📝 Open multiple browser tabs to test multi-user chat")
-    log.Println("💬 Messages publish to all connected users via ctx.Publish")
+    log.Println("💬 Messages sync across all connected browser tabs")
 
     http.ListenAndServe(":"+port, nil)
 }

--- a/chat/README.md
+++ b/chat/README.md
@@ -164,7 +164,7 @@ func (s *ChatState) updateOnlineCount() {
 
 - Actions route via `<form name="join">` and `<form name="send">` (button/form `name` routing)
 - `ctx.GetString("field")` extracts form data
-- Just modify state - broadcasting happens automatically!
+- Opt into peer fan-out in `Mount` with `ctx.Subscribe(ctx.SelfTopic())`, then call `ctx.Publish(ctx.SelfTopic(), "Action", nil)` from the action handler to reach the other tabs
 - No manual WebSocket code needed
 
 ### Step 4: Initialize and Run
@@ -203,7 +203,7 @@ func main() {
 
     log.Printf("🚀 Chat server starting on http://localhost:%s", port)
     log.Println("📝 Open multiple browser tabs to test multi-user chat")
-    log.Println("💬 Messages are broadcast to all connected users")
+    log.Println("💬 Messages publish to all connected users via ctx.Publish")
 
     http.ListenAndServe(":"+port, nil)
 }
@@ -312,7 +312,7 @@ Chrome Tab 1       Server (Go)        Chrome Tab 2
     |          [Same groupID: session-abc]    |
     |                   |                     |
     |--- send msg ----->|                     |
-    |         [Auto-broadcast to group]       |
+    |     [ctx.Publish fans out to group]     |
     |<---- update ------|------- update ----->|
     |                   |                     |
 ```
@@ -321,9 +321,9 @@ Chrome Tab 1       Server (Go)        Chrome Tab 2
 
 1. Each browser gets a unique session ID (stored in cookie)
 2. All tabs in the same browser share the session ID
-3. State changes automatically sync to all tabs in the same session
+3. Connections that subscribe via `ctx.Subscribe(ctx.SelfTopic())` receive `ctx.Publish` fan-outs from peer tabs in the same session
 4. Only changed HTML is sent (tree-diffing)
-5. Zero manual broadcasting code required!
+5. Peer fan-out is two lines (`Subscribe` + `Publish`) — no manual WebSocket plumbing
 
 ### Why So Simple?
 
@@ -341,7 +341,7 @@ Chrome Tab 1       Server (Go)        Chrome Tab 2
 
 - ✅ Just modify Go structs
 - ✅ 2 files total
-- ✅ Auto-broadcasting
+- ✅ Opt-in peer fan-out (`ctx.Subscribe` + `ctx.Publish`)
 - ✅ Auto-updates
 - ✅ Standard `html/template`
 - ✅ Standard `net/http`
@@ -383,7 +383,7 @@ case "typing":
     }
     ctx.Bind(&data)
     s.TypingUsers[data.Username] = true
-    // Auto-broadcast!
+    // Then publish to peer tabs: ctx.Publish(ctx.SelfTopic(), "UpdateTyping", nil)
 ```
 
 ### Add Message Reactions
@@ -502,7 +502,7 @@ The simple kit starts with a counter. Here's how we evolved it:
 |-----------------|--------------|
 | `AppState{Counter int}` | `ChatState{Messages []Message}` |
 | `increment/decrement` actions | `join/send` actions |
-| Single user | Multi-user with broadcasting |
+| Single user | Multi-user via `ctx.Publish` peer fan-out |
 | Simple int update | List of messages |
 
 Same pattern, different data!
@@ -516,6 +516,6 @@ Same pattern, different data!
 ## Related Documentation
 
 - [LiveTemplate Core Docs](../../README.md)
-- [Broadcasting Guide](../../docs/design/IMPLEMENTATION_STATUS.md)
+- [Pub/Sub Reference](https://github.com/livetemplate/livetemplate/blob/main/docs/references/pubsub.md)
 - [Template Syntax](https://pkg.go.dev/html/template)
 - [LiveTemplate API](https://pkg.go.dev/github.com/livetemplate/livetemplate)

--- a/chat/README.md
+++ b/chat/README.md
@@ -376,14 +376,15 @@ type ChatState struct {
     TypingUsers map[string]bool
 }
 
-// In Change()
+// In Mount() (prerequisite): ctx.Subscribe(ctx.SelfTopic())
+// In Change():
 case "typing":
     var data struct {
         Username string `json:"username"`
     }
     ctx.Bind(&data)
     s.TypingUsers[data.Username] = true
-    // Then publish to peer tabs: ctx.Publish(ctx.SelfTopic(), "UpdateTyping", nil)
+    ctx.Publish(ctx.SelfTopic(), "UpdateTyping", nil)
 ```
 
 ### Add Message Reactions

--- a/chat/main.go
+++ b/chat/main.go
@@ -64,7 +64,7 @@ func (c *ChatController) OnConnect(state ChatState, ctx *livetemplate.Context) (
 }
 
 // Join handles the "join" action when a user joins in this tab.
-// Sets CurrentUser on this connection only, then broadcasts to other tabs.
+// Sets CurrentUser on this connection only, then publishes to peer tabs.
 func (c *ChatController) Join(state ChatState, ctx *livetemplate.Context) (ChatState, error) {
 	username := ctx.GetString("username")
 	if username == "" {
@@ -98,7 +98,7 @@ func (c *ChatController) UserJoined(state ChatState, ctx *livetemplate.Context) 
 }
 
 // Send handles the "send" action to send a chat message.
-// Adds message to shared store, updates this tab, broadcasts to others.
+// Adds message to shared store, updates this tab, publishes to peer tabs.
 func (c *ChatController) Send(state ChatState, ctx *livetemplate.Context) (ChatState, error) {
 	text := ctx.GetString("message")
 	if text == "" || state.CurrentUser == "" {

--- a/counter/README.md
+++ b/counter/README.md
@@ -4,7 +4,7 @@ A real-time counter application demonstrating LiveTemplate's reactive state mana
 
 ## Features
 
-- **Reactive state**: Changes to state automatically generate updates; peer fan-out via opt-in `ctx.Subscribe(ctx.SelfTopic())` + `ctx.Publish(ctx.SelfTopic(), "Action", nil)`
+- **Reactive state**: Changes to state automatically generate updates; multi-tab sync via opt-in pub/sub (`ctx.Subscribe` + `ctx.Publish`)
 - **Transport-agnostic**: Works over WebSocket or plain HTTP/AJAX
 - **Minimal bandwidth**: Only the changed values are transmitted, not the entire HTML
 - **No custom JavaScript**: Uses only the LiveTemplate client library

--- a/counter/README.md
+++ b/counter/README.md
@@ -4,7 +4,7 @@ A real-time counter application demonstrating LiveTemplate's reactive state mana
 
 ## Features
 
-- **Reactive state**: Changes to state automatically generate and broadcast updates
+- **Reactive state**: Changes to state automatically generate updates; peer fan-out via opt-in `ctx.Subscribe(ctx.SelfTopic())` + `ctx.Publish(ctx.SelfTopic(), "Action", nil)`
 - **Transport-agnostic**: Works over WebSocket or plain HTTP/AJAX
 - **Minimal bandwidth**: Only the changed values are transmitted, not the entire HTML
 - **No custom JavaScript**: Uses only the LiveTemplate client library
@@ -217,7 +217,7 @@ Browser                    WebSocket/HTTP              Go Server
 │ Button name     │        │ Auto-    │               │ - Clones state   │
 │ routing         │        │ detects  │               │ - Generates      │
 │ (Tier 1 HTML)   │        │ transport│               │   updates        │
-│                 │        │          │               │ - Broadcasts     │
+│                 │        │          │               │ - Publishes      │
 └─────────────────┘        └──────────┘               └──────────────────┘
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/chromedp/chromedp v0.14.2
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/gorilla/websocket v1.5.3
-	github.com/livetemplate/livetemplate v0.9.2
+	github.com/livetemplate/livetemplate v0.10.1
 	github.com/livetemplate/lvt v0.1.6
 	github.com/livetemplate/lvt/components v0.1.2
 	modernc.org/sqlite v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/livetemplate/livetemplate v0.9.2 h1:zF/mbhXxp5uLX3UBdgkdBk+Jmhfx3g5DAlUCisTXoZM=
-github.com/livetemplate/livetemplate v0.9.2/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
+github.com/livetemplate/livetemplate v0.10.1 h1:pFOYbx1TE1G7Qp4ebIDvYlOBf8ZpKAWdJdU07Of+sE4=
+github.com/livetemplate/livetemplate v0.10.1/go.mod h1:GMvZKyPUq8LSGfgD3pftKOHa6v+I+RDYyff2mNjeAYs=
 github.com/livetemplate/lvt v0.1.6 h1:1rDU5hDo+EtZ0mT+868wYD9czF2EHEgdacS4kpIUPQ4=
 github.com/livetemplate/lvt v0.1.6/go.mod h1:OrTdx3zvh0WeuugVueQoRG3ILRNJe/dThErxKsos6Rw=
 github.com/livetemplate/lvt/components v0.1.2 h1:MM2M5IZnsUAu0py9ZbtcQCo0bvUrL4Z3Ly/yDkYNyag=

--- a/landing-demo/README.md
+++ b/landing-demo/README.md
@@ -17,7 +17,7 @@ Same code, three transports:
 Two pieces enable it:
 
 - `Count int \`lvt:"persist"\`` makes the field session-store backed, so it survives reconnects and is visible to every connection in the same session group.
-- `Mount` opts this connection into peer fan-out via `ctx.Subscribe(ctx.SelfTopic())`, and each counter handler ends with `ctx.Publish(ctx.SelfTopic(), "Increment", nil)` so peer tabs receive the same counter action and re-render.
+- `Mount` opts this connection into peer fan-out via `ctx.Subscribe(ctx.SelfTopic())`, and each counter handler ends with `ctx.Publish(ctx.SelfTopic(), actionName, nil)` (e.g. `"Increment"` or `"Decrement"`) so peer tabs receive the same action and re-render.
 
 Without the `Subscribe`/`Publish` pair, peer tabs would only see the latest value on their own next action or a full reload. Without `persist`, a full reload would not preserve the session count.
 

--- a/landing-demo/README.md
+++ b/landing-demo/README.md
@@ -17,9 +17,9 @@ Same code, three transports:
 Two pieces enable it:
 
 - `Count int \`lvt:"persist"\`` makes the field session-store backed, so it survives reconnects and is visible to every connection in the same session group.
-- The controller explicitly calls `ctx.BroadcastAction(...)` after counter mutations so peer tabs receive the same counter action and re-render.
+- `Mount` opts this connection into peer fan-out via `ctx.Subscribe(ctx.SelfTopic())`, and each counter handler ends with `ctx.Publish(ctx.SelfTopic(), "Increment", nil)` so peer tabs receive the same counter action and re-render.
 
-Without `BroadcastAction`, peer tabs would only see the latest value on their own next action or a full reload. Without `persist`, a full reload would not preserve the session count.
+Without the `Subscribe`/`Publish` pair, peer tabs would only see the latest value on their own next action or a full reload. Without `persist`, a full reload would not preserve the session count.
 
 ## Run locally
 

--- a/todos/README.md
+++ b/todos/README.md
@@ -13,7 +13,7 @@ A real-time todo application demonstrating LiveTemplate's controller pattern wit
 - **Sort** - Newest first, oldest first, alphabetical (A-Z / Z-A)
 - **Pagination** - 3 items per page with navigation controls
 - **Live statistics** - Real-time total, completed, and remaining counts
-- **Reactive updates** - Changes broadcast to all connected clients
+- **Reactive updates** - Changes publish to all subscribed peer tabs via `ctx.Publish(ctx.SelfTopic(), "RefreshTodos", nil)`
 - **SQLite persistence** - Todos survive server restarts
 
 ## Quick Start

--- a/todos/README.md
+++ b/todos/README.md
@@ -13,7 +13,7 @@ A real-time todo application demonstrating LiveTemplate's controller pattern wit
 - **Sort** - Newest first, oldest first, alphabetical (A-Z / Z-A)
 - **Pagination** - 3 items per page with navigation controls
 - **Live statistics** - Real-time total, completed, and remaining counts
-- **Reactive updates** - Changes publish to all subscribed peer tabs via `ctx.Publish(ctx.SelfTopic(), "RefreshTodos", nil)`
+- **Reactive updates** - Changes sync to peer tabs via opt-in pub/sub (`ctx.Subscribe` + `ctx.Publish`)
 - **SQLite persistence** - Todos survive server restarts
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Phase 6 (PR #103) migrated example controller code (chat, todos, shared-notepad, landing-demo, counter) from `ctx.BroadcastAction` to `ctx.Subscribe(ctx.SelfTopic())` + `ctx.Publish(ctx.SelfTopic(), ...)` but left several README / comment claims that still described the old API or the implicit-broadcast behavior that was removed in v0.10.0.

This PR is the docs/comment companion: it rewrites the stale prose to match what the code already does, and bumps `examples/go.mod` from `v0.9.2` to `v0.10.1` so standalone clones (not just go.work-overridden in-tree builds) compile.

## Changes

- **landing-demo/README.md** — Rewrites the "How cross-tab sync works" section. The prior text named `ctx.BroadcastAction(...)`, which no longer exists.
- **chat/README.md** — Drops "broadcasting happens automatically" / "Auto-broadcasting" claims that are factually wrong post-v0.10.0 (peer fan-out is opt-in via Subscribe/Publish).
- **chat/main.go** — Comment text "broadcasts to other tabs" → "publishes to peer tabs" above Join/Send handlers. The handler code already uses `ctx.Publish(ctx.SelfTopic(), ...)`.
- **counter/README.md** + **todos/README.md** — Light bullet rewording to reference Subscribe/Publish.
- **go.mod** — `github.com/livetemplate/livetemplate v0.9.2` → `v0.10.1`. (When v0.11.0 ships from livetemplate#431, this should bump again.)

## Verification

- ✅ `GOWORK=off go build ./...` passes.
- ✅ `./test-all.sh` chromedp e2e matrix: **12/12 examples pass** against the v0.10.1 pin (counter, chat, todos, live-preview, ws-disabled, login, shared-notepad, flash-messages, avatar-upload, progressive-enhancement, dialog-patterns, landing-demo).

## Out of scope

- The defunct "Broadcasting Guide" link to `docs/design/IMPLEMENTATION_STATUS.md` is redirected to the canonical `pubsub.md` reference. The old target page doesn't exist anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)